### PR TITLE
Add the duration parser utility

### DIFF
--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/Utils.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/Utils.kt
@@ -53,3 +53,17 @@ suspend inline fun <reified T : Event> Kord.waitFor(
         }
     }
 }
+
+/**
+ * Return a [Pair] made of the start of the string up to the first character matching the predicate excluded,
+ * and the rest of the string.
+ *
+ * @param predicate Predicate used to determine the split.
+ */
+fun String.splitOn(predicate: (Char) -> Boolean): Pair<String, String> {
+    val i = this.indexOfFirst(predicate)
+    if (i == -1) {
+        return Pair(this, "")
+    }
+    return Pair(this.slice(IntRange(0, i - 1)), this.slice(IntRange(i, this.length - 1)))
+}

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
@@ -13,7 +13,7 @@ val unitMap = mapOf(
     "second" to ChronoUnit.SECONDS,
     "seconds" to ChronoUnit.SECONDS,
 
-    "m" to ChronoUnit.MINUTES,
+    "mi" to ChronoUnit.MINUTES,
     "min" to ChronoUnit.MINUTES,
     "minute" to ChronoUnit.MINUTES,
     "minutes" to ChronoUnit.MINUTES,
@@ -30,7 +30,7 @@ val unitMap = mapOf(
     "week" to ChronoUnit.WEEKS,
     "weeks" to ChronoUnit.WEEKS,
 
-    "M" to ChronoUnit.MONTHS,
+    "mo" to ChronoUnit.MONTHS,
     "month" to ChronoUnit.MONTHS,
     "months" to ChronoUnit.MONTHS,
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
@@ -1,5 +1,6 @@
 package com.kotlindiscord.kord.extensions.parsers
 
+import com.kotlindiscord.kord.extensions.splitOn
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 
@@ -24,21 +25,20 @@ val unitMap = mapOf(
  */
 @Suppress("MagicNumber")
 fun parseDuration(s: String): Duration {
-    var buf = 0L
-    var unit: ChronoUnit? = null
-    val duration = Duration.ofSeconds(0)
+    var buffer = s
+    var duration = Duration.ofSeconds(0)
 
-    for (c in s) {
-        if (c.isDigit()) {
-            buf = buf * 10 + c.toLong()
-        } else {
-            if (unit != null) {
-                duration.plus(buf, unit)
-            }
+    while (buffer.isNotEmpty()) {
+        val r1 = buffer.splitOn { it.isLetter() } // Thanks Kotlin : https://youtrack.jetbrains.com/issue/KT-11362
+        val num = r1.first
+        buffer = r1.second
 
-            buf = 0L
-            unit = unitMap[c.toString()]
-        }
+        val r2 = buffer.splitOn { it.isDigit() }
+        val unit = r2.first
+        buffer = r2.second
+
+        val chronoUnit = unitMap[unit]
+        duration = duration.plus(num.toLong(), chronoUnit)
     }
 
     return duration

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
@@ -9,12 +9,34 @@ import java.time.temporal.ChronoUnit
  */
 val unitMap = mapOf(
     "s" to ChronoUnit.SECONDS,
+    "sec" to ChronoUnit.SECONDS,
+    "second" to ChronoUnit.SECONDS,
+    "seconds" to ChronoUnit.SECONDS,
+
     "m" to ChronoUnit.MINUTES,
+    "min" to ChronoUnit.MINUTES,
+    "minute" to ChronoUnit.MINUTES,
+    "minutes" to ChronoUnit.MINUTES,
+
     "h" to ChronoUnit.HOURS,
+    "hour" to ChronoUnit.HOURS,
+    "hours" to ChronoUnit.HOURS,
+
     "d" to ChronoUnit.DAYS,
+    "day" to ChronoUnit.DAYS,
+    "days" to ChronoUnit.DAYS,
+
     "w" to ChronoUnit.WEEKS,
+    "week" to ChronoUnit.WEEKS,
+    "weeks" to ChronoUnit.WEEKS,
+
     "M" to ChronoUnit.MONTHS,
-    "y" to ChronoUnit.YEARS
+    "month" to ChronoUnit.MONTHS,
+    "months" to ChronoUnit.MONTHS,
+
+    "y" to ChronoUnit.YEARS,
+    "year" to ChronoUnit.YEARS,
+    "years" to ChronoUnit.YEARS
 )
 
 /**
@@ -37,7 +59,7 @@ fun parseDuration(s: String): Duration {
         val unit = r2.first
         buffer = r2.second
 
-        val chronoUnit = unitMap[unit]
+        val chronoUnit = unitMap[unit.toLowerCase()]
         duration = duration.plus(num.toLong(), chronoUnit)
     }
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
@@ -1,0 +1,45 @@
+package com.kotlindiscord.kord.extensions.parsers
+
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+
+/**
+ * Mapping character to its actual unit.
+ */
+val unitMap = mapOf(
+    "s" to ChronoUnit.SECONDS,
+    "m" to ChronoUnit.MINUTES,
+    "h" to ChronoUnit.HOURS,
+    "d" to ChronoUnit.DAYS,
+    "w" to ChronoUnit.WEEKS,
+    "M" to ChronoUnit.MONTHS,
+    "y" to ChronoUnit.YEARS
+)
+
+/**
+ * Parse the provided string to a [Duration] object.
+ * Units are determined as in [unitMap].
+ *
+ * @param s the string to parse.
+ */
+@Suppress("MagicNumber")
+fun parseDuration(s: String): Duration {
+    var buf = 0L
+    var unit: ChronoUnit? = null
+    val duration = Duration.ofSeconds(0)
+
+    for (c in s) {
+        if (c.isDigit()) {
+            buf = buf * 10 + c.toLong()
+        } else {
+            if (unit != null) {
+                duration.plus(buf, unit)
+            }
+
+            buf = 0L
+            unit = unitMap[c.toString()]
+        }
+    }
+
+    return duration
+}


### PR DESCRIPTION
This PR adds a (sort of) standalone duration parser. 

I decided to not hook it up to the argument parser because I didn't actually need it, do you think it is a good idea to still hook it up?