### PR TITLE
Create base exception for parsers and throw custom exception when invalid time unit provided to parser

### DIFF
--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/Exceptions.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/Exceptions.kt
@@ -88,12 +88,3 @@ class ParseException(var reason: String) : ExtensionsException() {
 
     override fun toString(): String = reason
 }
-
-/**
- * Throws when invalid time unit given to duration parser.
- *
- * @param unit Invalid unit.
- */
-class InvalidTimeUnitException(var unit: String) : ExtensionsException() {
-    override fun toString(): String = "Invalid time unit provided: $unit"
-}

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/Exceptions.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/Exceptions.kt
@@ -88,3 +88,12 @@ class ParseException(var reason: String) : ExtensionsException() {
 
     override fun toString(): String = reason
 }
+
+/**
+ * Throws when invalid time unit given to duration parser.
+ *
+ * @param unit Invalid unit.
+ */
+class InvalidTimeUnitException(var unit: String) : ExtensionsException() {
+    override fun toString(): String = "Invalid time unit provided: $unit"
+}

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
@@ -3,7 +3,6 @@ package com.kotlindiscord.kord.extensions.parsers
 import com.kotlindiscord.kord.extensions.splitOn
 import java.time.Duration
 import java.time.temporal.ChronoUnit
-import kotlin.NoSuchElementException
 
 /**
  * Mapping character to its actual unit.

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
@@ -61,8 +61,9 @@ fun parseDuration(s: String): Duration {
         val unit = r2.first
         buffer = r2.second
         
+        val chronoUnit: ChronoUnit
         try {
-            val chronoUnit = unitMap.getValue(unit.toLowerCase())
+            chronoUnit = unitMap.getValue(unit.toLowerCase())
         } catch (e: NoSuchElementException) {
             throw InvalidTimeUnitException(unit.toLowerCase())
         }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
@@ -1,6 +1,5 @@
 package com.kotlindiscord.kord.extensions.parsers
 
-import com.kotlindiscord.kord.extensions.InvalidTimeUnitException
 import com.kotlindiscord.kord.extensions.splitOn
 import java.time.Duration
 import java.time.temporal.ChronoUnit

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
@@ -59,7 +59,7 @@ fun parseDuration(s: String): Duration {
         val unit = r2.first
         buffer = r2.second
 
-        val chronoUnit = unitMap[unit.toLowerCase()]
+        val chronoUnit = unitMap.getValue(unit.toLowerCase())
         duration = duration.plus(num.toLong(), chronoUnit)
     }
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
@@ -59,7 +59,7 @@ fun parseDuration(s: String): Duration {
         val r2 = buffer.splitOn { it.isDigit() }
         val unit = r2.first
         buffer = r2.second
-        
+
         val chronoUnit = unitMap[unit.toLowerCase()] ?: throw InvalidTimeUnitException(unit.toLowerCase())
         duration = duration.plus(num.toLong(), chronoUnit)
     }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
@@ -60,12 +60,7 @@ fun parseDuration(s: String): Duration {
         val unit = r2.first
         buffer = r2.second
         
-        val chronoUnit: ChronoUnit
-        try {
-            chronoUnit = unitMap.getValue(unit.toLowerCase())
-        } catch (e: NoSuchElementException) {
-            throw InvalidTimeUnitException(unit.toLowerCase())
-        }
+        val chronoUnit = unitMap[unit.toLowerCase()] ?: throw InvalidTimeUnitException(unit.toLowerCase())
         duration = duration.plus(num.toLong(), chronoUnit)
     }
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/DurationParser.kt
@@ -1,8 +1,10 @@
 package com.kotlindiscord.kord.extensions.parsers
 
+import com.kotlindiscord.kord.extensions.InvalidTimeUnitException
 import com.kotlindiscord.kord.extensions.splitOn
 import java.time.Duration
 import java.time.temporal.ChronoUnit
+import kotlin.NoSuchElementException
 
 /**
  * Mapping character to its actual unit.
@@ -58,8 +60,12 @@ fun parseDuration(s: String): Duration {
         val r2 = buffer.splitOn { it.isDigit() }
         val unit = r2.first
         buffer = r2.second
-
-        val chronoUnit = unitMap.getValue(unit.toLowerCase())
+        
+        try {
+            val chronoUnit = unitMap.getValue(unit.toLowerCase())
+        } catch (e: NoSuchElementException) {
+            throw InvalidTimeUnitException(unit.toLowerCase())
+        }
         duration = duration.plus(num.toLong(), chronoUnit)
     }
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/Exceptions.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/Exceptions.kt
@@ -1,0 +1,17 @@
+package com.kotlindiscord.kord.extensions.parsers
+
+import com.kotlindiscord.kord.extensions.ExtensionsException;
+
+/**
+ * A base exception class for parsers.
+ */
+open class BaseParserException() : ExtensionsException()
+
+/**
+ * Throws when invalid time unit given to duration parser.
+ *
+ * @param unit Invalid unit.
+ */
+class InvalidTimeUnitException(var unit: String) : BaseParserException() {
+    override fun toString(): String = "Invalid time unit provided: $unit"
+}

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/Exceptions.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/parsers/Exceptions.kt
@@ -1,11 +1,11 @@
 package com.kotlindiscord.kord.extensions.parsers
 
-import com.kotlindiscord.kord.extensions.ExtensionsException;
+import com.kotlindiscord.kord.extensions.ExtensionsException
 
 /**
  * A base exception class for parsers.
  */
-open class BaseParserException() : ExtensionsException()
+open class BaseParserException : ExtensionsException()
 
 /**
  * Throws when invalid time unit given to duration parser.


### PR DESCRIPTION
Currently this throws `NullPointerException` when invalid time unit provided, but catching `NullPointerException` is too generic, so now this throw custom exception.