### PR TITLE
Reloadable extensions

### DIFF
--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/ExtensibleBot.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/ExtensibleBot.kt
@@ -266,6 +266,8 @@ open class ExtensibleBot(
      * removes its event handlers and commands. Unloaded extensions can
      * be loaded again by calling [ExtensibleBot.loadExtension].
      *
+     * This function simply returns if the extension isn't found.
+     *
      * @param extension The name of the [Extension] to unload.
      */
     suspend fun unloadExtension(extension: String) {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/ExtensibleBot.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/ExtensibleBot.kt
@@ -80,12 +80,12 @@ open class ExtensibleBot(
     private suspend fun registerListeners() {
         kord.on<ReadyEvent> {
             if (!initialized) {  // We do this because a reconnect will cause this event to happen again.
-                for (extension in extensions.values) {
+                for (extension in extensions.keys) {
                     @Suppress("TooGenericExceptionCaught")  // Anything could happen here
                     try {
-                        extension.doSetup()
+                        loadExtension(extension)
                     } catch (e: Exception) {
-                        logger.error(e) { "Failed to set up '${extension.name}' extension." }
+                        logger.error(e) { "Failed to set up '$extension' extension." }
                     }
                 }
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/ExtensibleBot.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/ExtensibleBot.kt
@@ -248,6 +248,8 @@ open class ExtensibleBot(
      * removes its event handlers and commands. Unloaded extensions can
      * be loaded again by calling [ExtensibleBot.loadExtension].
      *
+     * This function simply returns if the extension isn't found.
+     *
      * @param extension The name of the [Extension] to unload.
      */
     @Throws(InvalidExtensionException::class)

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventHandler.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventHandler.kt
@@ -30,7 +30,7 @@ class EventHandler<T : Any>(val extension: Extension, val type: KClass<*>) {
     val checkList: MutableList<suspend (T) -> Boolean> = mutableListOf()
 
     /**
-     * @suppress
+     * @suppress This is the job returned by `Kord#on`, which we cancel to stop listening.
      */
     var job: Job? = null
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventHandler.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventHandler.kt
@@ -1,6 +1,5 @@
 package com.kotlindiscord.kord.extensions.events
 
-import com.gitlab.kordlib.core.event.Event
 import com.kotlindiscord.kord.extensions.InvalidEventHandlerException
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import kotlinx.coroutines.Job
@@ -19,7 +18,7 @@ private val logger = KotlinLogging.logger {}
  * @param extension The [Extension] that registered this event handler.
  * @param type A [KClass] representing the event type this handler is subscribed to. This is for internal use.
  */
-class EventHandler<T : Event>(val extension: Extension, val type: KClass<*>) {
+class EventHandler<T : Any>(val extension: Extension, val type: KClass<*>) {
     /**
      * @suppress
      */

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventHandler.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventHandler.kt
@@ -3,6 +3,7 @@ package com.kotlindiscord.kord.extensions.events
 import com.gitlab.kordlib.core.event.Event
 import com.kotlindiscord.kord.extensions.InvalidEventHandlerException
 import com.kotlindiscord.kord.extensions.extensions.Extension
+import kotlinx.coroutines.Job
 import mu.KotlinLogging
 import kotlin.reflect.KClass
 
@@ -28,6 +29,11 @@ class EventHandler<T : Event>(val extension: Extension, val type: KClass<*>) {
      * @suppress
      */
     val checkList: MutableList<suspend (T) -> Boolean> = mutableListOf()
+
+    /**
+     * @suppress
+     */
+    var job: Job? = null
 
     /**
      * An internal function used to ensure that all of an event handler's required arguments are present.

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/ExtensionEvent.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/ExtensionEvent.kt
@@ -1,0 +1,11 @@
+package com.kotlindiscord.kord.extensions.events
+
+import com.kotlindiscord.kord.extensions.ExtensibleBot
+
+/**
+ * Base interface for events fired by Kord Extensions.
+ */
+interface ExtensionEvent {
+    /** Current bot instance for this event. **/
+    val bot: ExtensibleBot
+}

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/ExtensionLoadedEvent.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/ExtensionLoadedEvent.kt
@@ -1,0 +1,11 @@
+package com.kotlindiscord.kord.extensions.events
+
+import com.kotlindiscord.kord.extensions.ExtensibleBot
+import com.kotlindiscord.kord.extensions.extensions.Extension
+
+/**
+ * Event fired when an extension is loaded, either on first load or programmatically later.
+ *
+ * @param extension The extension that's just been loaded.
+ */
+class ExtensionLoadedEvent(override val bot: ExtensibleBot, val extension: Extension) : ExtensionEvent

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/ExtensionUnloadedEvent.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/ExtensionUnloadedEvent.kt
@@ -1,0 +1,11 @@
+package com.kotlindiscord.kord.extensions.events
+
+import com.kotlindiscord.kord.extensions.ExtensibleBot
+import com.kotlindiscord.kord.extensions.extensions.Extension
+
+/**
+ * Event fired when an extension is unloaded programmatically.
+ *
+ * @param extension The extension that's just been unloaded.
+ */
+class ExtensionUnloadedEvent(override val bot: ExtensibleBot, val extension: Extension) : ExtensionEvent


### PR DESCRIPTION
This PR updates the API a bit to allow for reloadable extensions.

This does not implement an extension that reloads other extensions - it just provides a way for extensions to be unloaded and loaded.

This PR also implements custom events that are fired when extensions are loaded and unloaded.