### PR TITLE
Grouped commands / Additional modularity

### DIFF
--- a/docs/src/orchid/resources/wiki/components/command.md
+++ b/docs/src/orchid/resources/wiki/components/command.md
@@ -174,3 +174,42 @@ The parser supports the following types:
 
 **Note:** `GuildEmoji` and `Role` objects will be retrieved from the within the current guild. It is not possible
 to specify which guild to use at this time, but we may add support for that later.
+
+#### Command Groups
+
+You may also define command groups. Command groups are essentially commands that have their own subcommands.
+
+```kotlin
+override suspend fun setup() {
+    group { // this: GroupedCommand
+        name = "tag"
+
+        command { // this: Command
+            name = "get"
+
+            action { // this: CommandContext
+                message.channel.createMessage("Get tag!")
+            }
+        }
+
+        command { // this: Command
+            name = "put"
+
+            action { // this: CommandContext
+                message.channel.createMessage("Put tag!")
+            }
+        }
+    }
+}
+```
+
+Upon execution, a grouped command will attempt to find a subcommand matching the first argument passed to
+it, executing it if a matching subcommand exists. If there's no matching subcommand, the grouped command
+will execute its own body instead.
+
+The body of a grouped command will send an error to the user by default. You can override this behaviour by using
+the `action` function, as you would for any command.
+
+Aside from the above, grouped commands behave exactly like any other command. You can use checks, define a signature
+for the action, and so on. Grouped commands provide the same `command` and `group` function that extensions do,
+which means that command groups can contain their own command groups!

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/ExtensibleBot.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/ExtensibleBot.kt
@@ -61,7 +61,10 @@ open class ExtensibleBot(
      */
     open val extensions: MutableMap<String, Extension> = mutableMapOf()
 
+    /** @suppress **/
     open val eventPublisher = BroadcastChannel<Any>(Channel.CONFLATED)
+
+    /** @suppress **/
     open var initialized: Boolean = false
 
     /** A [Flow] representing a combined set of Kord events and Kord Extensions events. **/

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/Paginator.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/Paginator.kt
@@ -35,7 +35,7 @@ private val logger = KotlinLogging.logger {}
  * @param timeout Milliseconds before automatically deleting the embed. Set to a negative value to disable it.
  * @param keepEmbed Keep the embed and only remove the reaction when the paginator is destroyed.
  */
-class Paginator(
+open class Paginator(
     val bot: ExtensibleBot,
     val channel: MessageChannelBehavior,
     val name: String,
@@ -45,15 +45,15 @@ class Paginator(
     val keepEmbed: Boolean = false
 ) {
     /** Message containing the embed. **/
-    var message: Message? = null
+    open var message: Message? = null
     /** Current page of the paginator. **/
-    var currentPage: Int = 0
+    open var currentPage: Int = 0
     /** Whether the paginator still processes reaction events. **/
-    var doesProcessEvents: Boolean = true
+    open var doesProcessEvents: Boolean = true
 
     /** Send the embed to the channel given in the constructor. **/
     @KordPreview
-    suspend fun send() {
+    open suspend fun send() {
         val myFooter = EmbedBuilder.Footer()
         myFooter.text = "Page 1/${pages.size}"
 
@@ -87,7 +87,7 @@ class Paginator(
      *
      * @param event [ReactionAddEvent] to process.
      */
-    suspend fun processEvent(event: ReactionAddEvent) {
+    open suspend fun processEvent(event: ReactionAddEvent) {
         logger.debug { "Paginator received emoji ${event.emoji.name}" }
         event.message.deleteReaction(event.userId, event.emoji)
 
@@ -105,7 +105,7 @@ class Paginator(
      *
      * @param page Page number to display.
      */
-    suspend fun goToPage(page: Int) {
+    open suspend fun goToPage(page: Int) {
         if (page == currentPage) {
             return
         }
@@ -130,7 +130,7 @@ class Paginator(
      * This will make it stops receive [ReactionAddEvent] and will delete the embed if `keepEmbed` is set to true,
      * or will delete all the reactions if it is set to false.
      */
-    suspend fun destroy() {
+    open suspend fun destroy() {
         if (!keepEmbed) {
             message?.delete()
         } else {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/ArgumentParser.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/ArgumentParser.kt
@@ -31,8 +31,11 @@ private val logger = KotlinLogging.logger {}
 open class ArgumentParser(private val bot: ExtensibleBot) {
     /** Defined here so we don't have to create it every time we try to parse something. */
     open val listType = List::class.createType(arguments = listOf(KTypeProjection.STAR))
+
+    /** @suppress **/
     open val nullableListType = List::class.createType(arguments = listOf(KTypeProjection.STAR), nullable = true)
 
+    /** @suppress **/
     open val mentionRegex = Regex("^<(?:@[!&]?|#)(\\d+)>$")
 
     /**
@@ -68,6 +71,7 @@ open class ArgumentParser(private val bot: ExtensibleBot) {
         }
     }
 
+    /** @suppress **/
     @Throws(ParseException::class)
     open suspend fun <T : Any> doParse(
         dataclass: KClass<T>,
@@ -132,6 +136,7 @@ open class ArgumentParser(private val bot: ExtensibleBot) {
         }
     }
 
+    /** @suppress **/
     open suspend fun stringToType(string: String, type: KType, event: MessageCreateEvent): Any? {
         @Suppress("TooGenericExceptionCaught")  // As usual, anything can happen here.
         return when {
@@ -262,6 +267,7 @@ open class ArgumentParser(private val bot: ExtensibleBot) {
         }
     }
 
+    /** @suppress **/
     open suspend fun stringsToTypes(strings: Array<out String>, type: KType, event: MessageCreateEvent): List<Any?> {
         val values: MutableList<Any?> = mutableListOf()
 
@@ -270,6 +276,7 @@ open class ArgumentParser(private val bot: ExtensibleBot) {
         return values
     }
 
+    /** @suppress **/
     open fun parseMention(string: String): String {
         if (string.toLongOrNull() != null) {
             return string

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/ArgumentParser.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/ArgumentParser.kt
@@ -28,12 +28,12 @@ private val logger = KotlinLogging.logger {}
  *
  * @param bot Instance of [ExtensibleBot] we're working with.
  */
-class ArgumentParser(private val bot: ExtensibleBot) {
+open class ArgumentParser(private val bot: ExtensibleBot) {
     /** Defined here so we don't have to create it every time we try to parse something. */
-    private val listType = List::class.createType(arguments = listOf(KTypeProjection.STAR))
-    private val nullableListType = List::class.createType(arguments = listOf(KTypeProjection.STAR), nullable = true)
+    open val listType = List::class.createType(arguments = listOf(KTypeProjection.STAR))
+    open val nullableListType = List::class.createType(arguments = listOf(KTypeProjection.STAR), nullable = true)
 
-    private val mentionRegex = Regex("^<(?:@[!&]?|#)(\\d+)>$")
+    open val mentionRegex = Regex("^<(?:@[!&]?|#)(\\d+)>$")
 
     /**
      * Given a data class and an array of strings, return an instance of the data class that
@@ -47,7 +47,7 @@ class ArgumentParser(private val bot: ExtensibleBot) {
      * @throws ParseException Thrown if the arguments couldn't be parsed for some reason.
      */
     @Throws(ParseException::class)
-    suspend fun <T : Any> parse(dataclass: KClass<T>, args: Array<out String>, event: MessageCreateEvent): T {
+    open suspend fun <T : Any> parse(dataclass: KClass<T>, args: Array<out String>, event: MessageCreateEvent): T {
         if (!dataclass.isData) {
             throw ParseException("Given class is not a data class.")
         }
@@ -69,7 +69,7 @@ class ArgumentParser(private val bot: ExtensibleBot) {
     }
 
     @Throws(ParseException::class)
-    private suspend fun <T : Any> doParse(
+    open suspend fun <T : Any> doParse(
         dataclass: KClass<T>,
         args: Array<out String>,
         event: MessageCreateEvent,
@@ -132,7 +132,7 @@ class ArgumentParser(private val bot: ExtensibleBot) {
         }
     }
 
-    private suspend fun stringToType(string: String, type: KType, event: MessageCreateEvent): Any? {
+    open suspend fun stringToType(string: String, type: KType, event: MessageCreateEvent): Any? {
         @Suppress("TooGenericExceptionCaught")  // As usual, anything can happen here.
         return when {
             type.isSubtypeOf(String::class.createType()) ||
@@ -262,7 +262,7 @@ class ArgumentParser(private val bot: ExtensibleBot) {
         }
     }
 
-    private suspend fun stringsToTypes(strings: Array<out String>, type: KType, event: MessageCreateEvent): List<Any?> {
+    open suspend fun stringsToTypes(strings: Array<out String>, type: KType, event: MessageCreateEvent): List<Any?> {
         val values: MutableList<Any?> = mutableListOf()
 
         strings.forEach { values.add(stringToType(it, type, event)) }
@@ -270,7 +270,7 @@ class ArgumentParser(private val bot: ExtensibleBot) {
         return values
     }
 
-    private fun parseMention(string: String): String {
+    open fun parseMention(string: String): String {
         if (string.toLongOrNull() != null) {
             return string
         }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/Command.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/Command.kt
@@ -26,11 +26,11 @@ val listType = List::class.createType(arguments = listOf(KTypeProjection.STAR))
  *
  * @param extension The [Extension] that registered this command.
  */
-class Command(val extension: Extension) {
+open class Command(val extension: Extension) {
     /**
      * @suppress
      */
-    lateinit var body: suspend CommandContext.() -> Unit
+    open lateinit var body: suspend CommandContext.() -> Unit
 
     /**
      * The name of this command, for invocation and help commands.
@@ -134,7 +134,6 @@ class Command(val extension: Extension) {
      * Overloaded check function to allow for DSL syntax.
      *
      * @param check Check to apply to this command.
-     * @sample com.kotlindiscord.kord.extensions.samples.CommandCheckSample.setup
      */
     fun check(check: suspend (MessageCreateEvent) -> Boolean) {
         checkList.add(check)
@@ -202,8 +201,8 @@ class Command(val extension: Extension) {
      *
      * @param event The message creation event.
      */
-    suspend fun call(event: MessageCreateEvent, args: Array<String>) {
-        if (!runChecks(event)) {
+    open suspend fun call(event: MessageCreateEvent, args: Array<String>, skipChecks: Boolean = false) {
+        if (skipChecks || !runChecks(event)) {
             return
         }
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/Command.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/Command.kt
@@ -35,14 +35,14 @@ open class Command(val extension: Extension) {
     /**
      * The name of this command, for invocation and help commands.
      */
-    lateinit var name: String
+    open lateinit var name: String
 
     /**
      * A description of what this function and how it's intended to be used.
      *
      * This is intended to be made use of by help commands.
      */
-    var description: String = "No description provided."
+    open var description: String = "No description provided."
 
     /**
      * Whether this command is enabled and can be invoked.
@@ -52,14 +52,14 @@ open class Command(val extension: Extension) {
      * This can be changed at runtime, if commands need to be enabled and disabled dynamically without being
      * reconstructed.
      */
-    var enabled: Boolean = true
+    open var enabled: Boolean = true
 
     /**
      * Whether to hide this command from help command listings.
      *
      * By default, this is `false` - so the command will be shown.
      */
-    var hidden: Boolean = false
+    open var hidden: Boolean = false
 
     /**
      * The command signature, specifying how the command's arguments should be structured.
@@ -68,7 +68,7 @@ open class Command(val extension: Extension) {
      * a dataclass to generate a signature, or you can specify this in the [Extension.command] builder function
      * if you'd like to provide something a bit more specific.
      */
-    var signature: String = ""
+    open var signature: String = ""
 
     /**
      * Alternative names that can be used to invoke your command.
@@ -76,17 +76,17 @@ open class Command(val extension: Extension) {
      * There's no limit on the number of aliases a command may have, but in the event of an alias matching
      * the [name] of a registered command, the command with the [name] takes priority.
      */
-    var aliases: Array<String> = arrayOf()
+    open var aliases: Array<String> = arrayOf()
 
     /**
      * @suppress
      */
-    val checkList: MutableList<suspend (MessageCreateEvent) -> Boolean> = mutableListOf()
+    open val checkList: MutableList<suspend (MessageCreateEvent) -> Boolean> = mutableListOf()
 
     /**
      * @suppress
      */
-    val parser = ArgumentParser(extension.bot)
+    open val parser = ArgumentParser(extension.bot)
 
     /**
      * An internal function used to ensure that all of a command's required arguments are present.
@@ -94,7 +94,7 @@ open class Command(val extension: Extension) {
      * @throws InvalidCommandException Thrown when a required argument hasn't been set.
      */
     @Throws(InvalidCommandException::class)
-    fun validate() {
+    open fun validate() {
         if (!::name.isInitialized) {
             throw InvalidCommandException(null, "No command name given.")
         }
@@ -111,7 +111,7 @@ open class Command(val extension: Extension) {
      *
      * @param action The body of your command, which will be executed when your command is invoked.
      */
-    fun action(action: suspend CommandContext.() -> Unit) {
+    open fun action(action: suspend CommandContext.() -> Unit) {
         this.body = action
     }
 
@@ -126,7 +126,7 @@ open class Command(val extension: Extension) {
      *
      * @param checks Checks to apply to this command.
      */
-    fun check(vararg checks: suspend (MessageCreateEvent) -> Boolean) {
+    open fun check(vararg checks: suspend (MessageCreateEvent) -> Boolean) {
         checks.forEach { checkList.add(it) }
     }
 
@@ -135,7 +135,7 @@ open class Command(val extension: Extension) {
      *
      * @param check Check to apply to this command.
      */
-    fun check(check: suspend (MessageCreateEvent) -> Boolean) {
+    open fun check(check: suspend (MessageCreateEvent) -> Boolean) {
         checkList.add(check)
     }
 
@@ -180,7 +180,7 @@ open class Command(val extension: Extension) {
     }
 
     /** Run checks with the provided [MessageCreateEvent]. Return false if any failed, true otherwise. **/
-    suspend fun runChecks(event: MessageCreateEvent): Boolean {
+    open suspend fun runChecks(event: MessageCreateEvent): Boolean {
         for (check in checkList) {
             if (!check.invoke(event)) {
                 return false

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/Command.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/Command.kt
@@ -202,7 +202,7 @@ open class Command(val extension: Extension) {
      * @param event The message creation event.
      */
     open suspend fun call(event: MessageCreateEvent, args: Array<String>, skipChecks: Boolean = false) {
-        if (skipChecks || !runChecks(event)) {
+        if (!skipChecks && !runChecks(event)) {
             return
         }
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/CommandContext.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/CommandContext.kt
@@ -13,15 +13,15 @@ import com.kotlindiscord.kord.extensions.ParseException
  * @param event Event that triggered this command.
  * @param args Array of string arguments for this command.
  */
-class CommandContext(
-    val command: Command,
-    val event: MessageCreateEvent,
-    val args: Array<String>
+open class CommandContext(
+    open val command: Command,
+    open val event: MessageCreateEvent,
+    open val args: Array<String>
 ) {
     /**
      * Message object representing the message that invoked the command.
      */
-    val message by lazy { event.message }
+    open val message by lazy { event.message }
 
     /**
      * Attempt to parse the arguments in this CommandContext into a given data class.

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/GroupCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/GroupCommand.kt
@@ -1,0 +1,120 @@
+package com.kotlindiscord.kord.extensions.commands
+
+import com.gitlab.kordlib.core.event.message.MessageCreateEvent
+import com.kotlindiscord.kord.extensions.CommandRegistrationException
+import com.kotlindiscord.kord.extensions.InvalidCommandException
+import com.kotlindiscord.kord.extensions.extensions.Extension
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Class representing a grouped command, which is essentially a command with its own subcommands.
+ *
+ * You shouldn't need to use this class directly - instead, create an `Extension` and use the
+ * `group` function to register your command group, by overriding the `Extension` setup function.
+ *
+ * @param extension The extension that registered this grouped command.
+ */
+class GroupCommand(extension: Extension) : Command(extension) {
+    /** @suppress **/
+    val commands = mutableListOf<Command>()
+
+    /** @suppress **/
+    override var body: suspend CommandContext.() -> Unit = {
+        val mention = message.author!!.mention
+
+        val error = if (args.size > 0) {
+            "$mention Unknown subcommand: ${args.first()}"
+        } else {
+            "$mention Subcommands: " + commands.joinToString(", ") { "`${it.name}`" }
+        }
+
+        message.channel.createMessage(error)
+    }
+
+    /**
+     * DSL function for easily registering a command.
+     *
+     * Use this in your setup function to register a command that may be executed on Discord.
+     *
+     * @param body Builder lambda used for setting up the command object.
+     */
+    suspend fun command(body: suspend Command.() -> Unit): Command {
+        val commandObj = Command(extension)
+
+        body.invoke(commandObj)
+
+        try {
+            commandObj.validate()
+            commands.add(commandObj)
+        } catch (e: CommandRegistrationException) {
+            logger.error(e) { "Failed to register subcommand - $e" }
+        } catch (e: InvalidCommandException) {
+            logger.error(e) { "Failed to register subcommand - $e" }
+        }
+
+        return commandObj
+    }
+
+    /**
+     * DSL function for easily registering a grouped command.
+     *
+     * Use this in your setup function to register a group of commands.
+     *
+     * The body of the grouped command will be executed if there is no
+     * matching subcommand.
+     *
+     * @param body Builder lambda used for setting up the command object.
+     */
+    suspend fun group(body: suspend GroupCommand.() -> Unit): GroupCommand {
+        val commandObj = GroupCommand(extension)
+
+        body.invoke(commandObj)
+
+        try {
+            commandObj.validate()
+            commands.add(commandObj)
+        } catch (e: CommandRegistrationException) {
+            logger.error(e) { "Failed to register command - $e" }
+        } catch (e: InvalidCommandException) {
+            logger.error(e) { "Failed to register command - $e" }
+        }
+
+        return commandObj
+    }
+
+    /** @suppress **/
+    fun getCommand(commandName: String?) =
+        commands.firstOrNull { it.name == commandName } ?: commands.firstOrNull { it.aliases.contains(commandName) }
+
+    /**
+     * Execute this grouped command, given a [MessageCreateEvent].
+     *
+     * This function takes a [MessageCreateEvent] (generated when a message is received), and
+     * processes it. The command's checks are invoked and, assuming all of the
+     * checks passed, the command will search for a subcommand matching the first argument.
+     * If a subcommand is found, it will be executed - otherwise, the the
+     * [command body][action] is executed.
+     *
+     * If an exception is thrown by the [command body][action], it is caught and a traceback
+     * is printed.
+     *
+     * @param event The message creation event.
+     */
+    override suspend fun call(event: MessageCreateEvent, args: Array<String>, skipChecks: Boolean) {
+        if (skipChecks || !runChecks(event)) {
+            return
+        }
+
+        val commandName = args.firstOrNull()?.toLowerCase()
+        val remainingArgs = args.drop(1).toTypedArray()
+        val subCommand = getCommand(commandName)
+
+        if (subCommand == null) {
+            super.call(event, args, true)
+        } else {
+            subCommand.call(event, remainingArgs)
+        }
+    }
+}

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/GroupCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/GroupCommand.kt
@@ -20,12 +20,30 @@ open class GroupCommand(extension: Extension) : Command(extension) {
     /** @suppress **/
     open val commands = mutableListOf<Command>()
 
+    override lateinit var name: String
+
+    /**
+     * An internal function used to ensure that all of a command group's required arguments are present.
+     *
+     * @throws InvalidCommandException Thrown when a required argument hasn't been set.
+     */
+    @Throws(InvalidCommandException::class)
+    override fun validate() {
+        if (!::name.isInitialized) {
+            throw InvalidCommandException(null, "No command name given.")
+        }
+
+        if (commands.isEmpty()) {
+            throw InvalidCommandException(name, "No subcommands registered.")
+        }
+    }
+
     /** @suppress **/
     override var body: suspend CommandContext.() -> Unit = {
         val mention = message.author!!.mention
 
         val error = if (args.size > 0) {
-            "$mention Unknown subcommand: ${args.first()}"
+            "$mention Unknown subcommand: `${args.first()}`"
         } else {
             "$mention Subcommands: " + commands.joinToString(", ") { "`${it.name}`" }
         }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/GroupCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/GroupCommand.kt
@@ -42,9 +42,19 @@ open class GroupCommand(extension: Extension) : Command(extension) {
      */
     open suspend fun command(body: suspend Command.() -> Unit): Command {
         val commandObj = Command(extension)
-
         body.invoke(commandObj)
 
+        return command(commandObj)
+    }
+
+    /**
+     * Function for registering a custom command object.
+     *
+     * You can use this if you have a custom command subclass you need to register.
+     *
+     * @param commandObj Command object to register.
+     */
+    open suspend fun command(commandObj: Command): Command {
         try {
             commandObj.validate()
             commands.add(commandObj)
@@ -69,19 +79,9 @@ open class GroupCommand(extension: Extension) : Command(extension) {
      */
     open suspend fun group(body: suspend GroupCommand.() -> Unit): GroupCommand {
         val commandObj = GroupCommand(extension)
-
         body.invoke(commandObj)
 
-        try {
-            commandObj.validate()
-            commands.add(commandObj)
-        } catch (e: CommandRegistrationException) {
-            logger.error(e) { "Failed to register command - $e" }
-        } catch (e: InvalidCommandException) {
-            logger.error(e) { "Failed to register command - $e" }
-        }
-
-        return commandObj
+        return command(commandObj) as GroupCommand
     }
 
     /** @suppress **/

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/GroupCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/GroupCommand.kt
@@ -16,9 +16,9 @@ private val logger = KotlinLogging.logger {}
  *
  * @param extension The extension that registered this grouped command.
  */
-class GroupCommand(extension: Extension) : Command(extension) {
+open class GroupCommand(extension: Extension) : Command(extension) {
     /** @suppress **/
-    val commands = mutableListOf<Command>()
+    open val commands = mutableListOf<Command>()
 
     /** @suppress **/
     override var body: suspend CommandContext.() -> Unit = {
@@ -40,7 +40,7 @@ class GroupCommand(extension: Extension) : Command(extension) {
      *
      * @param body Builder lambda used for setting up the command object.
      */
-    suspend fun command(body: suspend Command.() -> Unit): Command {
+    open suspend fun command(body: suspend Command.() -> Unit): Command {
         val commandObj = Command(extension)
 
         body.invoke(commandObj)
@@ -67,7 +67,7 @@ class GroupCommand(extension: Extension) : Command(extension) {
      *
      * @param body Builder lambda used for setting up the command object.
      */
-    suspend fun group(body: suspend GroupCommand.() -> Unit): GroupCommand {
+    open suspend fun group(body: suspend GroupCommand.() -> Unit): GroupCommand {
         val commandObj = GroupCommand(extension)
 
         body.invoke(commandObj)
@@ -85,7 +85,7 @@ class GroupCommand(extension: Extension) : Command(extension) {
     }
 
     /** @suppress **/
-    fun getCommand(commandName: String?) =
+    open fun getCommand(commandName: String?) =
         commands.firstOrNull { it.name == commandName } ?: commands.firstOrNull { it.aliases.contains(commandName) }
 
     /**

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/extensions/Extension.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/extensions/Extension.kt
@@ -44,7 +44,7 @@ abstract class Extension(val bot: ExtensibleBot) {
     /**
      * @suppress This is an internal API function used as part of extension lifecycle management.
      */
-    suspend fun doSetup() {
+    open suspend fun doSetup() {
         this.setup()
         loaded = true
 
@@ -57,7 +57,7 @@ abstract class Extension(val bot: ExtensibleBot) {
      * This is set during loading/unloading of the extension and is used to ensure
      * things aren't being called when they shouldn't be.
      */
-    var loaded = false
+    open var loaded = false
 
     /**
      * List of registered event handlers.
@@ -65,14 +65,14 @@ abstract class Extension(val bot: ExtensibleBot) {
      * When an extension is unloaded, all the event handlers are cancelled and
      * removed from the bot.
      */
-    val eventHandlers = mutableListOf<EventHandler<out Any>>()
+    open val eventHandlers = mutableListOf<EventHandler<out Any>>()
 
     /**
      * List of registered commands.
      *
      * When an extension is unloaded, all the commands are removed from the bot.
      */
-    val commands = mutableListOf<Command>()
+    open val commands = mutableListOf<Command>()
 
     /**
      * DSL function for easily registering a command.
@@ -81,7 +81,7 @@ abstract class Extension(val bot: ExtensibleBot) {
      *
      * @param body Builder lambda used for setting up the command object.
      */
-    suspend fun command(body: suspend Command.() -> Unit): Command {
+    open suspend fun command(body: suspend Command.() -> Unit): Command {
         val commandObj = Command(this)
 
         body.invoke(commandObj)
@@ -109,7 +109,7 @@ abstract class Extension(val bot: ExtensibleBot) {
      *
      * @param body Builder lambda used for setting up the command object.
      */
-    suspend fun group(body: suspend GroupCommand.() -> Unit): GroupCommand {
+    open suspend fun group(body: suspend GroupCommand.() -> Unit): GroupCommand {
         val commandObj = GroupCommand(this)
 
         body.invoke(commandObj)
@@ -146,7 +146,7 @@ abstract class Extension(val bot: ExtensibleBot) {
      *
      * @suppress Internal function
      */
-    suspend fun doUnload() {
+    open suspend fun doUnload() {
         this.unload()
 
         for (handler in eventHandlers) {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/extensions/Extension.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/extensions/Extension.kt
@@ -2,6 +2,7 @@ package com.kotlindiscord.kord.extensions.extensions
 
 import com.kotlindiscord.kord.extensions.*
 import com.kotlindiscord.kord.extensions.commands.Command
+import com.kotlindiscord.kord.extensions.commands.GroupCommand
 import com.kotlindiscord.kord.extensions.events.EventHandler
 import com.kotlindiscord.kord.extensions.events.ExtensionLoadedEvent
 import com.kotlindiscord.kord.extensions.events.ExtensionUnloadedEvent
@@ -82,6 +83,34 @@ abstract class Extension(val bot: ExtensibleBot) {
      */
     suspend fun command(body: suspend Command.() -> Unit): Command {
         val commandObj = Command(this)
+
+        body.invoke(commandObj)
+
+        try {
+            commandObj.validate()
+            bot.addCommand(commandObj)
+            commands.add(commandObj)
+        } catch (e: CommandRegistrationException) {
+            logger.error(e) { "Failed to register command - $e" }
+        } catch (e: InvalidCommandException) {
+            logger.error(e) { "Failed to register command - $e" }
+        }
+
+        return commandObj
+    }
+
+    /**
+     * DSL function for easily registering a grouped command.
+     *
+     * Use this in your setup function to register a group of commands.
+     *
+     * The body of the grouped command will be executed if there is no
+     * matching subcommand.
+     *
+     * @param body Builder lambda used for setting up the command object.
+     */
+    suspend fun group(body: suspend GroupCommand.() -> Unit): GroupCommand {
+        val commandObj = GroupCommand(this)
 
         body.invoke(commandObj)
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/extensions/Extension.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/extensions/Extension.kt
@@ -83,9 +83,19 @@ abstract class Extension(val bot: ExtensibleBot) {
      */
     open suspend fun command(body: suspend Command.() -> Unit): Command {
         val commandObj = Command(this)
-
         body.invoke(commandObj)
 
+        return command(commandObj)
+    }
+
+    /**
+     * Function for registering a custom command object.
+     *
+     * You can use this if you have a custom command subclass you need to register.
+     *
+     * @param commandObj Command object to register.
+     */
+    open suspend fun command(commandObj: Command): Command {
         try {
             commandObj.validate()
             bot.addCommand(commandObj)
@@ -111,20 +121,9 @@ abstract class Extension(val bot: ExtensibleBot) {
      */
     open suspend fun group(body: suspend GroupCommand.() -> Unit): GroupCommand {
         val commandObj = GroupCommand(this)
-
         body.invoke(commandObj)
 
-        try {
-            commandObj.validate()
-            bot.addCommand(commandObj)
-            commands.add(commandObj)
-        } catch (e: CommandRegistrationException) {
-            logger.error(e) { "Failed to register command - $e" }
-        } catch (e: InvalidCommandException) {
-            logger.error(e) { "Failed to register command - $e" }
-        }
-
-        return commandObj
+        return command(commandObj) as GroupCommand
     }
 
     /**

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/extensions/HelpExtension.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/extensions/HelpExtension.kt
@@ -5,6 +5,7 @@ import com.gitlab.kordlib.core.event.message.MessageCreateEvent
 import com.kotlindiscord.kord.extensions.ExtensibleBot
 import com.kotlindiscord.kord.extensions.Paginator
 import com.kotlindiscord.kord.extensions.commands.Command
+import com.kotlindiscord.kord.extensions.commands.GroupCommand
 import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
@@ -25,9 +26,9 @@ class HelpExtension(bot: ExtensibleBot) : Extension(bot) {
         command {
             name = "help"
             aliases = arrayOf("h")
-            description = "Get help.\n" +
-                    "\n" +
-                    "Let's just pretend we have a lot of things to say here"
+            description = "Get command help.\n" +
+                "\n" +
+                "Specify the name of a command to get help for that specific command."
             signature = "[command]"
 
             action {
@@ -43,7 +44,7 @@ class HelpExtension(bot: ExtensibleBot) : Extension(bot) {
                     ).send()
                 } else {
                     message.channel.createEmbed {
-                        val command = getCommand(args[0])
+                        val command = getCommand(args)
 
                         title = "Command Help"
                         description = if (command == null) {
@@ -58,7 +59,7 @@ class HelpExtension(bot: ExtensibleBot) : Extension(bot) {
     }
 
     /**
-     * Gather all available commands from the bot, and return them as an array of [KDCommand].
+     * Gather all available commands from the bot, and return them as an array of [Command].
      */
     suspend fun gatherCommands(event: MessageCreateEvent) =
         bot.commands.filter { !it.hidden && it.enabled && it.runChecks(event) }
@@ -70,16 +71,34 @@ class HelpExtension(bot: ExtensibleBot) : Extension(bot) {
         return commands.sortedBy { it.name }.chunked(HELP_PER_PAGE).map { list ->
             list.joinToString(separator = "\n\n") { command ->
                 with(command) {
-                    "**${bot.prefix}$name $signature**\n${description.takeWhile { it != '\n' }}"
+                    var desc = "**${bot.prefix}$name $signature**\n${description.takeWhile { it != '\n' }}"
+
+                    if (command is GroupCommand) {
+                        desc += "\n\n**Subcommands:** " + command.commands.joinToString(", ") { "`$it.name`" }
+                    }
+
+                    desc
                 }
             }
         }
     }
 
     /**
-     * Return the [Command] of the associated name, or null if it cannot be found.
+     * Return the [Command] specified in the arguments, or null if it can't be found.
      */
-    fun getCommand(command: String) = bot.commands.firstOrNull { it.name == command || it.aliases.contains(command) }
+    fun getCommand(args: Array<String>): Command? {
+        val firstArg = args.first()
+
+        var command: Command? = bot.commands.firstOrNull { it.name == firstArg || it.aliases.contains(firstArg) }
+
+        args.drop(1).forEach {
+            if (command != null && command is GroupCommand) {
+                command = (command as GroupCommand).getCommand(it)
+            }
+        }
+
+        return command
+    }
 
     /**
      * Format the given command's description into a short help string.
@@ -87,7 +106,13 @@ class HelpExtension(bot: ExtensibleBot) : Extension(bot) {
      * @param command The command to format the description of.
      */
     fun formatLongHelp(command: Command): String {
-        return "**${bot.prefix}${command.name} ${command.signature}**\n\n" +
-                "*${command.description}*"
+        var desc = "**${bot.prefix}${command.name} ${command.signature}**\n\n" +
+            "*${command.description}*"
+
+        if (command is GroupCommand) {
+            desc += "\n\n**Subcommands:** " + command.commands.joinToString(", ") { "`$it.name`" }
+        }
+
+        return desc
     }
 }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/extensions/HelpExtension.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/extensions/HelpExtension.kt
@@ -74,7 +74,7 @@ class HelpExtension(bot: ExtensibleBot) : Extension(bot) {
                     var desc = "**${bot.prefix}$name $signature**\n${description.takeWhile { it != '\n' }}"
 
                     if (command is GroupCommand) {
-                        desc += "\n\n**Subcommands:** " + command.commands.joinToString(", ") { "`$it.name`" }
+                        desc += "\n\n**Subcommands:** " + command.commands.joinToString(", ") { "`${it.name}`" }
                     }
 
                     desc
@@ -110,7 +110,7 @@ class HelpExtension(bot: ExtensibleBot) : Extension(bot) {
             "*${command.description}*"
 
         if (command is GroupCommand) {
-            desc += "\n\n**Subcommands:** " + command.commands.joinToString(", ") { "`$it.name`" }
+            desc += "\n\n**Subcommands:** " + command.commands.joinToString(", ") { "`${it.name}`" }
         }
 
         return desc


### PR DESCRIPTION
This adds a `group` function to extensions and a new `GroupCommand` class.

`GroupCommand`s are essentially _command commands_ - they're commands with their own subcommands.
Grouped commands can also contain their own command groups, because who doesn't love nesting things waaaaaaaaaaaaaay too deep.

This also updates the help extension in line with the other changes. That said, this needs testing - any takers?

---

I've also taken the opportunity to modify a bunch of stuff because extensibility to the max is quite important - now you can register custom command classes, and a bunch of classes may be subclassed and have their attributes and methods overridden.