### PR TITLE
fix: Remove listener when channel or guild is deleted

### DIFF
--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/message/MessageEventManager.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/message/MessageEventManager.kt
@@ -300,6 +300,8 @@ public open class MessageEventManager(
      *
      * @see [MessageDeleteEvent]
      * @see [MessageBulkDeleteEvent]
+     * @see [ChannelDeleteEvent]
+     * @see [GuildDeleteEvent]
      */
     private fun isDeleteEvent(event: Event): Boolean =
         event is MessageDeleteEvent ||

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/message/MessageEventManager.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/message/MessageEventManager.kt
@@ -23,7 +23,7 @@ public const val DEFAULT_TIMEOUT: Long = 1000L * 60L * 5L
  * Message event manager, in charge of registering (and dispatching to) message-specific event handlers.
  *
  * @property message Message to listen to events for.
- * @property guildId Message guild ID
+ * @property guildId Message guild ID.
  * @property timeout How long to wait before cancelling listening, after the last relevant event.
  */
 public open class MessageEventManager(
@@ -199,7 +199,7 @@ public open class MessageEventManager(
     /**
      * Listen for [ChannelDeleteEvent]s for the tracked message.
      *
-     * This function will listen for channel deletes where is the message is located
+     * This function will listen for channel deletes where is the message is located.
      *
      * @param block Lambda (or function) to execute when a matching event is fired.
      *
@@ -217,7 +217,7 @@ public open class MessageEventManager(
     /**
      * Listen for [GuildDeleteEvent]s for the tracked message.
      *
-     * This function will listen for guild deletes where is the message is located
+     * This function will listen for guild deletes where is the message is located.
      *
      * @param block Lambda (or function) to execute when a matching event is fired.
      *

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/message/MessageEventManager.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/message/MessageEventManager.kt
@@ -152,10 +152,10 @@ public open class MessageEventManager(
      *
      * @see [event]
      */
-    public open fun delete(block: suspend () -> Unit) {
+    public open fun delete(block: suspend (Event) -> Unit) {
         event {
             if (isDeleteEvent(it)) {
-                block()
+                block(it)
             }
         }
     }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Message.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Message.kt
@@ -137,8 +137,8 @@ public suspend inline fun MessageBehavior.deleteOwnReaction(unicode: String): Un
  *
  * @receiver Message to listen to events for.
  *
- * @param launch `true` to launch the listening instantly, `false` otherwise.
  * @param timeout Time to wait (in millis) after the last relevant event before stopping, defaulting to 5 minutes.
+ * @param launch `true` to launch the listening instantly, `false` otherwise.
  * @param builder Event manager builder - use this to register your event listeners.
  *
  * @return The newly-created [MessageEventManager] instance.
@@ -148,8 +148,8 @@ public suspend inline fun MessageBehavior.deleteOwnReaction(unicode: String): Un
  */
 @Throws(IllegalStateException::class)
 public suspend inline fun Message.events(
-    launch: Boolean = true,
     timeout: Long? = DEFAULT_TIMEOUT,
+    launch: Boolean = true,
     builder: MessageEventManager.() -> Unit
 ): MessageEventManager {
     val guildId = withStrategy(EntitySupplyStrategy.cacheWithRestFallback).getGuildOrNull()?.id

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Message.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Message.kt
@@ -79,9 +79,9 @@ public fun MessageBehavior.delete(millis: Long, retry: Boolean = true): Job {
 /**
  * Add a reaction to this message, using the Unicode emoji represented by the given string.
  *
- * @param emoji Emoji to add to the message.
+ * @param unicode Emoji to add to the message.
  */
-public suspend inline fun MessageBehavior.addReaction(emoji: String): Unit = addReaction(emoji.toReaction())
+public suspend inline fun MessageBehavior.addReaction(unicode: String): Unit = addReaction(unicode.toReaction())
 
 /**
  * Remove a reaction from this message, using a guild's custom emoji object.
@@ -109,7 +109,7 @@ public suspend inline fun MessageBehavior.deleteReaction(emoji: GuildEmoji): Uni
 /**
  * Remove a reaction from this message, using the Unicode emoji represented by the given string.
  *
- * @param emoji Emoji to remove from the message.
+ * @param unicode Emoji to remove from the message.
  */
 public suspend inline fun MessageBehavior.deleteReaction(unicode: String): Unit = deleteReaction(unicode.toReaction())
 
@@ -124,7 +124,7 @@ public suspend inline fun MessageBehavior.deleteOwnReaction(emoji: GuildEmoji): 
 /**
  * Remove a reaction from this message belonging to the bot, using the Unicode emoji represented by the given string.
  *
- * @param emoji Emoji to remove from the message.
+ * @param unicode Emoji to remove from the message.
  */
 public suspend inline fun MessageBehavior.deleteOwnReaction(unicode: String): Unit =
     deleteOwnReaction(unicode.toReaction())
@@ -137,7 +137,7 @@ public suspend inline fun MessageBehavior.deleteOwnReaction(unicode: String): Un
  *
  * @receiver Message to listen to events for.
  *
- * @param start `true` to start the listening instantly, `false` otherwise
+ * @param start `true` to start the listening instantly, `false` otherwise.
  * @param timeout Time to wait (in millis) after the last relevant event before stopping, defaulting to 5 minutes.
  * @param builder Event manager builder - use this to register your event listeners.
  *

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Message.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Message.kt
@@ -137,7 +137,7 @@ public suspend inline fun MessageBehavior.deleteOwnReaction(unicode: String): Un
  *
  * @receiver Message to listen to events for.
  *
- * @param start `true` to start the listening instantly, `false` otherwise.
+ * @param launch `true` to launch the listening instantly, `false` otherwise.
  * @param timeout Time to wait (in millis) after the last relevant event before stopping, defaulting to 5 minutes.
  * @param builder Event manager builder - use this to register your event listeners.
  *
@@ -148,7 +148,7 @@ public suspend inline fun MessageBehavior.deleteOwnReaction(unicode: String): Un
  */
 @Throws(IllegalStateException::class)
 public suspend inline fun Message.events(
-    start: Boolean = true,
+    launch: Boolean = true,
     timeout: Long? = DEFAULT_TIMEOUT,
     builder: MessageEventManager.() -> Unit
 ): MessageEventManager {
@@ -157,7 +157,7 @@ public suspend inline fun Message.events(
     return MessageEventManager(this, guildId, timeout).apply {
         builder(this)
 
-        if (start) {
+        if (launch) {
             check(start()) { "Failed to listen for events: Already listening (this should never happen!)" }
         }
     }


### PR DESCRIPTION
# Why

In the previous version of the event system for messages. Some event that deleted the message was not supported _(ChannelDeleteEvent & GuildDeleteEvent)_.

This version fixes that and allows not to keep the event listener when the channel or guild is deleted