### PR TITLE
Allow comments in .env file when using the env function

### DIFF
--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Environment.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Environment.kt
@@ -7,7 +7,6 @@ import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.Path
 import kotlin.io.path.isRegularFile
 import kotlin.io.path.readLines
-import kotlin.system.exitProcess
 
 private var firstLoad: Boolean = true
 private var logger = KotlinLogging.logger {}

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Environment.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Environment.kt
@@ -35,8 +35,9 @@ public fun env(name: String): String? {
 
             for (line in lines) {
                 var effectiveLine = line.trimStart()
-                if (effectiveLine.startsWith("#"))
+                if (effectiveLine.startsWith("#")) {
                     continue
+                }
 
                 if (effectiveLine.contains("#")) {
                     effectiveLine = effectiveLine.substring(0, effectiveLine.indexOf("#"))

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Environment.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Environment.kt
@@ -39,7 +39,7 @@ public fun env(name: String): String? {
                     continue
 
                 if (effectiveLine.contains("#")) {
-                    effectiveLine = effectiveLine.substring(0, line.indexOf("#"))
+                    effectiveLine = effectiveLine.substring(0, effectiveLine.indexOf("#"))
                 }
 
                 if (!effectiveLine.contains('=')) {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Environment.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Environment.kt
@@ -35,10 +35,10 @@ public fun env(name: String): String? {
             val lines = dotenvFile.readLines()
 
             for (line in lines) {
-                if (line.startsWith("#"))
+                var effectiveLine = line.trimStart()
+                if (effectiveLine.startsWith("#"))
                     continue
 
-                var effectiveLine = line
                 if (line.contains("#")) {
                     effectiveLine = effectiveLine.substring(0, line.indexOf("#"))
                 }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Environment.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Environment.kt
@@ -38,7 +38,7 @@ public fun env(name: String): String? {
                 if (effectiveLine.startsWith("#"))
                     continue
 
-                if (line.contains("#")) {
+                if (effectiveLine.contains("#")) {
                     effectiveLine = effectiveLine.substring(0, line.indexOf("#"))
                 }
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Environment.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Environment.kt
@@ -7,6 +7,7 @@ import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.Path
 import kotlin.io.path.isRegularFile
 import kotlin.io.path.readLines
+import kotlin.system.exitProcess
 
 private var firstLoad: Boolean = true
 private var logger = KotlinLogging.logger {}
@@ -34,21 +35,29 @@ public fun env(name: String): String? {
             val lines = dotenvFile.readLines()
 
             for (line in lines) {
-                if (!line.contains('=')) {
+                if (line.startsWith("#"))
+                    continue
+
+                var effectiveLine = line
+                if (line.contains("#")) {
+                    effectiveLine = effectiveLine.substring(0, line.indexOf("#"))
+                }
+
+                if (!effectiveLine.contains('=')) {
                     logger.warn {
                         "Invalid line in dotenv file: \"=\" not found\n" +
-                            "    $line"
+                            "    $effectiveLine"
                     }
 
                     continue
                 }
 
-                val split = line.split("=", limit = 2)
+                val split = effectiveLine.split("=", limit = 2)
 
                 if (split.size != 2) {
                     logger.warn {
                         "Invalid line in dotenv file: variables must be of the form \"name=value\"\n" +
-                            " -> $line"
+                            " -> $effectiveLine"
                     }
 
                     continue


### PR DESCRIPTION
Before this pr, using the `env()` function, if you have comments in your file it would give warnings, this pr fixes it.