### PR TITLE
insert semicolon in Lclass;method for mixin target

### DIFF
--- a/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/utils/Mappings.kt
+++ b/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/utils/Mappings.kt
@@ -326,7 +326,7 @@ fun methodsToPages(
                 text += "\n"
 
                 text += "**Mixin Target** `" +
-                    "L${clazz.optimumName}" +
+                    "L${clazz.optimumName};" +
                     method.optimumName +
                     mappedDesc +
                     "`"


### PR DESCRIPTION
Fixes an issue where Mixin targets for methods would not have the `;` between class and method descriptors