### PR TITLE
1.5.2: Move to converter builders (#126, fixes #116)

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -4,15 +4,7 @@
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="kotlin">
-      <option name="CALL_PARAMETERS_WRAP" value="5" />
-      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
-      <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
-      <option name="METHOD_PARAMETERS_WRAP" value="5" />
-      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
-      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
-      <option name="EXTENDS_LIST_WRAP" value="1" />
-      <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-      <option name="ASSIGNMENT_WRAP" value="1" />
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
       </indentOptions>

--- a/.idea/fileTemplates/JavaFXApplication.java
+++ b/.idea/fileTemplates/JavaFXApplication.java
@@ -1,0 +1,23 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#if (${PACKAGE_NAME} && ${PACKAGE_NAME} != "")package ${PACKAGE_NAME};#end
+
+import javafx.application.Application;
+import javafx.stage.Stage;
+
+#parse("File Header.java")
+public class ${NAME} extends Application {
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+
+    @Override
+    public void start(Stage primaryStage) {
+        
+    }
+}

--- a/.idea/fileTemplates/internal/AnnotationType.java
+++ b/.idea/fileTemplates/internal/AnnotationType.java
@@ -1,0 +1,10 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#if (${PACKAGE_NAME} && ${PACKAGE_NAME} != "")package ${PACKAGE_NAME};#end
+#parse("File Header.java")
+public @interface ${NAME} {
+}

--- a/.idea/fileTemplates/internal/CSS File.css
+++ b/.idea/fileTemplates/internal/CSS File.css
@@ -1,0 +1,6 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+

--- a/.idea/fileTemplates/internal/Class.java
+++ b/.idea/fileTemplates/internal/Class.java
@@ -1,0 +1,10 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#if (${PACKAGE_NAME} && ${PACKAGE_NAME} != "")package ${PACKAGE_NAME};#end
+#parse("File Header.java")
+public class ${NAME} {
+}

--- a/.idea/fileTemplates/internal/Enum.java
+++ b/.idea/fileTemplates/internal/Enum.java
@@ -1,0 +1,10 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#if (${PACKAGE_NAME} && ${PACKAGE_NAME} != "")package ${PACKAGE_NAME};#end
+#parse("File Header.java")
+public enum ${NAME} {
+}

--- a/.idea/fileTemplates/internal/Gant Script.gant
+++ b/.idea/fileTemplates/internal/Gant Script.gant
@@ -1,0 +1,11 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#parse("File Header.java")
+
+target('default': 'The default target') {
+  
+}

--- a/.idea/fileTemplates/internal/Gradle Build Script with wrapper.gradle
+++ b/.idea/fileTemplates/internal/Gradle Build Script with wrapper.gradle
@@ -1,0 +1,21 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#if (${MODULE_GROUP} && ${MODULE_GROUP} != "")
+group '${MODULE_GROUP}'
+#end
+#if (${MODULE_VERSION} && ${MODULE_VERSION} != "")
+version '${MODULE_VERSION}'
+#end
+
+task wrapper(type: Wrapper) {
+#if (${GRADLE_VERSION} && ${GRADLE_VERSION} != "")
+  gradleVersion = '${GRADLE_VERSION}'
+#else
+  gradleVersion = '5.2.1'
+#end
+  distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
+}

--- a/.idea/fileTemplates/internal/Gradle Build Script.gradle
+++ b/.idea/fileTemplates/internal/Gradle Build Script.gradle
@@ -1,0 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#if (${MODULE_GROUP} && ${MODULE_GROUP} != "")
+group '${MODULE_GROUP}'
+#end
+#if (${MODULE_VERSION} && ${MODULE_VERSION} != "")
+version '${MODULE_VERSION}'
+#end

--- a/.idea/fileTemplates/internal/Groovy Annotation.groovy
+++ b/.idea/fileTemplates/internal/Groovy Annotation.groovy
@@ -1,0 +1,13 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#if (${PACKAGE_NAME} && $PACKAGE_NAME != "" )package ${PACKAGE_NAME}
+#end
+#parse("File Header.java")
+
+@interface ${NAME} {
+
+}

--- a/.idea/fileTemplates/internal/Groovy Class.groovy
+++ b/.idea/fileTemplates/internal/Groovy Class.groovy
@@ -1,0 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#if (${PACKAGE_NAME} && $PACKAGE_NAME != "" )package ${PACKAGE_NAME}
+#end
+
+#parse("File Header.java")
+class ${NAME} {
+}

--- a/.idea/fileTemplates/internal/Groovy DSL Script.gdsl
+++ b/.idea/fileTemplates/internal/Groovy DSL Script.gdsl
@@ -1,0 +1,7 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#parse("File Header.java")

--- a/.idea/fileTemplates/internal/Groovy Enum.groovy
+++ b/.idea/fileTemplates/internal/Groovy Enum.groovy
@@ -1,0 +1,13 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#if (${PACKAGE_NAME} && $PACKAGE_NAME != "" )package ${PACKAGE_NAME}
+#end
+
+#parse("File Header.java")
+enum ${NAME} {
+
+}

--- a/.idea/fileTemplates/internal/Groovy Interface.groovy
+++ b/.idea/fileTemplates/internal/Groovy Interface.groovy
@@ -1,0 +1,13 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#if (${PACKAGE_NAME} && $PACKAGE_NAME != "" )package ${PACKAGE_NAME}
+#end
+
+#parse("File Header.java")
+interface ${NAME} {
+
+}

--- a/.idea/fileTemplates/internal/Groovy Script.groovy
+++ b/.idea/fileTemplates/internal/Groovy Script.groovy
@@ -1,0 +1,10 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#if (${PACKAGE_NAME} && $PACKAGE_NAME != "" )package ${PACKAGE_NAME}
+#end
+
+#parse("File Header.java")

--- a/.idea/fileTemplates/internal/Groovy Trait.groovy
+++ b/.idea/fileTemplates/internal/Groovy Trait.groovy
@@ -1,0 +1,13 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#if (${PACKAGE_NAME} && $PACKAGE_NAME != "" )package ${PACKAGE_NAME}
+#end
+
+#parse("File Header.java")
+trait ${NAME} {
+
+}

--- a/.idea/fileTemplates/internal/Interface.java
+++ b/.idea/fileTemplates/internal/Interface.java
@@ -1,0 +1,10 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#if (${PACKAGE_NAME} && ${PACKAGE_NAME} != "")package ${PACKAGE_NAME};#end
+#parse("File Header.java")
+public interface ${NAME} {
+}

--- a/.idea/fileTemplates/internal/JavaScript File.js
+++ b/.idea/fileTemplates/internal/JavaScript File.js
@@ -1,0 +1,6 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+

--- a/.idea/fileTemplates/internal/Kotlin Class.kt
+++ b/.idea/fileTemplates/internal/Kotlin Class.kt
@@ -1,0 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#if (${PACKAGE_NAME} && ${PACKAGE_NAME} != "")package ${PACKAGE_NAME}
+
+#end
+#parse("File Header.java")
+class ${NAME} {
+}

--- a/.idea/fileTemplates/internal/Kotlin Enum.kt
+++ b/.idea/fileTemplates/internal/Kotlin Enum.kt
@@ -1,0 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#if (${PACKAGE_NAME} && ${PACKAGE_NAME} != "")package ${PACKAGE_NAME}
+
+#end
+#parse("File Header.java")
+enum class ${NAME} {
+}

--- a/.idea/fileTemplates/internal/Kotlin File.kt
+++ b/.idea/fileTemplates/internal/Kotlin File.kt
@@ -1,0 +1,10 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#if (${PACKAGE_NAME} && ${PACKAGE_NAME} != "")package ${PACKAGE_NAME}
+
+#end
+#parse("File Header.java")

--- a/.idea/fileTemplates/internal/Kotlin Interface.kt
+++ b/.idea/fileTemplates/internal/Kotlin Interface.kt
@@ -1,0 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#if (${PACKAGE_NAME} && ${PACKAGE_NAME} != "")package ${PACKAGE_NAME}
+
+#end
+#parse("File Header.java")
+interface ${NAME} {
+}

--- a/.idea/fileTemplates/internal/Kotlin Script.kts
+++ b/.idea/fileTemplates/internal/Kotlin Script.kts
@@ -1,0 +1,6 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+

--- a/.idea/fileTemplates/internal/Kotlin Worksheet.kts
+++ b/.idea/fileTemplates/internal/Kotlin Worksheet.kts
@@ -1,0 +1,6 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+

--- a/.idea/fileTemplates/internal/Less File.less
+++ b/.idea/fileTemplates/internal/Less File.less
@@ -1,0 +1,6 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+

--- a/.idea/fileTemplates/internal/Record.java
+++ b/.idea/fileTemplates/internal/Record.java
@@ -1,0 +1,10 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#if (${PACKAGE_NAME} && ${PACKAGE_NAME} != "")package ${PACKAGE_NAME};#end
+#parse("File Header.java")
+public record ${NAME}() {
+}

--- a/.idea/fileTemplates/internal/SCSS File.scss
+++ b/.idea/fileTemplates/internal/SCSS File.scss
@@ -1,0 +1,6 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+

--- a/.idea/fileTemplates/internal/Sass File.sass
+++ b/.idea/fileTemplates/internal/Sass File.sass
@@ -1,0 +1,6 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+

--- a/.idea/fileTemplates/internal/Stylus File.styl
+++ b/.idea/fileTemplates/internal/Stylus File.styl
@@ -1,0 +1,6 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+

--- a/.idea/fileTemplates/internal/TypeScript File.ts
+++ b/.idea/fileTemplates/internal/TypeScript File.ts
@@ -1,0 +1,6 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+

--- a/.idea/fileTemplates/internal/TypeScript JSX File.tsx
+++ b/.idea/fileTemplates/internal/TypeScript JSX File.tsx
@@ -1,0 +1,6 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+

--- a/.idea/fileTemplates/internal/module-info.java
+++ b/.idea/fileTemplates/internal/module-info.java
@@ -1,0 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#parse("File Header.java")
+module #[[$MODULE_NAME$]]# {
+}

--- a/.idea/fileTemplates/internal/package-info.java
+++ b/.idea/fileTemplates/internal/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#parse("File Header.java")
+#if (${PACKAGE_NAME} && ${PACKAGE_NAME} != "")package ${PACKAGE_NAME};#end

--- a/.idea/templateLanguages.xml
+++ b/.idea/templateLanguages.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="TemplateDataLanguageMappings">
+    <file url="PROJECT" dialect="kotlin" />
+  </component>
+</project>

--- a/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/_Utils.kt
+++ b/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/_Utils.kt
@@ -45,3 +45,11 @@ public fun String.maybe(bool: Boolean, callback: (String) -> String): String = i
 }
 
 public fun String.maybe(predicate: () -> Boolean, callback: (String) -> String): String = maybe(predicate(), callback)
+
+public fun <T> Collection<T>.containsAny(vararg items: T): Boolean {
+    items.forEach {
+        if (this.contains(it)) return true
+    }
+
+    return false
+}

--- a/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/_Utils.kt
+++ b/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/_Utils.kt
@@ -53,3 +53,36 @@ public fun <T> Collection<T>.containsAny(vararg items: T): Boolean {
 
     return false
 }
+
+public fun String?.orNull(): String? =
+    if (this.isNullOrEmpty()) {
+        null
+    } else {
+        this
+    }
+
+// Credit: https://stackoverflow.com/a/59737650
+public fun <T> List<T>.permutations(): Set<List<T>> {
+    if (this.isEmpty()) {
+        return emptySet()
+    }
+
+    val permutationInstructions = this.toSet()
+        .map { it to this.count { x -> x == it } }
+        .fold(listOf(setOf<Pair<T, Int>>())) { acc, (value, valueCount) ->
+            mutableListOf<Set<Pair<T, Int>>>().apply {
+                for (set in acc) for (retainIndex in 0 until valueCount) add(set + (value to retainIndex))
+            }
+        }
+
+    return mutableSetOf<List<T>>().also { outSet ->
+        for (instructionSet in permutationInstructions) {
+            outSet += this.toMutableList().apply {
+                for ((value, retainIndex) in instructionSet) {
+                    repeat(retainIndex) { removeAt(indexOfFirst { it == value }) }
+                    repeat(count { it == value } - 1) { removeAt(indexOfLast { it == value }) }
+                }
+            }
+        }
+    }
+}

--- a/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/ConverterAnnotationArgs.kt
+++ b/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/ConverterAnnotationArgs.kt
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+@file:Suppress("UncheckedCast")
+
 package com.kotlindiscord.kord.extensions.modules.annotations.converters
 
 import com.google.devtools.ksp.symbol.KSAnnotation
@@ -47,6 +49,10 @@ public data class ConverterAnnotationArgs(public val annotation: KSAnnotation) {
     /** @suppress **/
     public val builderFields: ArrayList<String> =
         argMap["builderFields"] as ArrayList<String>? ?: arrayListOf()
+
+    /** @suppress **/
+    public val builderExtraStatements: ArrayList<String> =
+        argMap["builderExtraStatements"] as ArrayList<String>? ?: arrayListOf()
 
     /** @suppress **/
     public val builderInitStatements: ArrayList<String> =

--- a/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/ConverterAnnotationArgs.kt
+++ b/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/ConverterAnnotationArgs.kt
@@ -1,0 +1,58 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.kotlindiscord.kord.extensions.modules.annotations.converters
+
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSType
+import com.kotlindiscord.kord.extensions.modules.annotations.orNull
+
+/**
+ * Class representing the arguments that are defined within a converter annotation, extracted from its declaration.
+ *
+ * @property annotation Annotation definition to extract data from.
+ */
+public data class ConverterAnnotationArgs(public val annotation: KSAnnotation) {
+    /** @suppress **/
+    private val argMap: Map<String?, Any?> =
+        annotation.arguments
+            .associate { it.name?.getShortName() to it.value }
+            .filterKeys { it != null }
+
+    /** @suppress **/
+    public val names: ArrayList<String> =
+        argMap["names"] as ArrayList<String>? ?: arrayListOf()
+
+    /** @suppress **/
+    public val types: List<ConverterType> =
+        (argMap["types"]!! as ArrayList<KSType>).mapNotNull {
+            ConverterType.fromName(it.declaration.simpleName.asString())
+        }
+
+    /** @suppress **/
+    public val imports: ArrayList<String> =
+        argMap["imports"] as ArrayList<String>? ?: arrayListOf()
+
+    /** @suppress **/
+    public val builderConstructorArguments: ArrayList<String> =
+        argMap["builderConstructorArguments"] as ArrayList<String>? ?: arrayListOf()
+
+    /** @suppress **/
+    public val builderGeneric: String? =
+        (argMap["builderGeneric"] as String).orNull()
+
+    /** @suppress **/
+    public val builderFields: ArrayList<String> =
+        argMap["builderFields"] as ArrayList<String>? ?: arrayListOf()
+
+    /** @suppress **/
+    public val functionGeneric: String? =
+        (argMap["functionGeneric"] as String).orNull()
+
+    /** @suppress **/
+    public val functionBuilderArguments: ArrayList<String> =
+        argMap["functionBuilderArguments"] as ArrayList<String>? ?: arrayListOf()
+}

--- a/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/ConverterAnnotationArgs.kt
+++ b/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/ConverterAnnotationArgs.kt
@@ -49,10 +49,22 @@ public data class ConverterAnnotationArgs(public val annotation: KSAnnotation) {
         argMap["builderFields"] as ArrayList<String>? ?: arrayListOf()
 
     /** @suppress **/
+    public val builderInitStatements: ArrayList<String> =
+        argMap["builderInitStatements"] as ArrayList<String>? ?: arrayListOf()
+
+    /** @suppress **/
+    public val builderSuffixedWhere: String? =
+        (argMap["builderSuffixedWhere"] as String).orNull()
+
+    /** @suppress **/
     public val functionGeneric: String? =
         (argMap["functionGeneric"] as String).orNull()
 
     /** @suppress **/
     public val functionBuilderArguments: ArrayList<String> =
         argMap["functionBuilderArguments"] as ArrayList<String>? ?: arrayListOf()
+
+    /** @suppress **/
+    public val functionSuffixedWhere: String? =
+        (argMap["functionSuffixedWhere"] as String).orNull()
 }

--- a/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/builders/ConverterBuilderClassBuilder.kt
+++ b/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/builders/ConverterBuilderClassBuilder.kt
@@ -173,16 +173,6 @@ public class ConverterBuilderClassBuilder : KoinComponent {
 
         builder.append(" {\n")
 
-        if (builderInitStatements.isNotEmpty()) {
-            builder.append("    init {\n")
-
-            builderInitStatements.forEach {
-                builder.append("        $it\n")
-            }
-
-            builder.append("    }\n\n")
-        }
-
         if (ConverterType.CHOICE in types) {
             builder.append("    override var choices: MutableMap<String, $argumentType> = mutableMapOf()\n\n")
         }
@@ -193,6 +183,16 @@ public class ConverterBuilderClassBuilder : KoinComponent {
             }
 
             builder.append("\n")
+        }
+
+        if (builderInitStatements.isNotEmpty()) {
+            builder.append("    init {\n")
+
+            builderInitStatements.forEach {
+                builder.append("        $it\n")
+            }
+
+            builder.append("    }\n\n")
         }
 
         if (builderExtraStatements.isNotEmpty()) {

--- a/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/builders/ConverterBuilderClassBuilder.kt
+++ b/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/builders/ConverterBuilderClassBuilder.kt
@@ -246,6 +246,8 @@ public class ConverterBuilderClassBuilder : KoinComponent {
             builder.append("            )")
         }
 
+        builder.append(".withBuilder(this)")
+
         builder.append("\n")
         builder.append("        )\n")
         builder.append("    }\n")

--- a/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/builders/ConverterBuilderClassBuilder.kt
+++ b/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/builders/ConverterBuilderClassBuilder.kt
@@ -49,6 +49,7 @@ public class ConverterBuilderClassBuilder : KoinComponent {
     internal val builderFields: MutableList<String> = mutableListOf()
     internal val builderFieldNames: MutableList<String> = mutableListOf()
 
+    internal val builderExtraStatements: MutableList<String> = mutableListOf()
     internal val builderInitStatements: MutableList<String> = mutableListOf()
 
     internal val types: MutableSet<ConverterType> = mutableSetOf()
@@ -74,6 +75,11 @@ public class ConverterBuilderClassBuilder : KoinComponent {
     public fun builderField(field: String) {
         builderFields.add(field)
         builderFieldNames.add(field.split(":").first().split(" ").last())
+    }
+
+    /** Add a builder init statement. **/
+    public fun builderExtraStatement(line: String) {
+        builderExtraStatements.add(line)
     }
 
     /** Add a builder init statement. **/
@@ -183,6 +189,14 @@ public class ConverterBuilderClassBuilder : KoinComponent {
 
         if (builderFields.isNotEmpty()) {
             builderFields.forEach {
+                builder.append("    $it\n")
+            }
+
+            builder.append("\n")
+        }
+
+        if (builderExtraStatements.isNotEmpty()) {
+            builderExtraStatements.forEach {
                 builder.append("    $it\n")
             }
 

--- a/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/builders/ConverterBuilderClassBuilder.kt
+++ b/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/builders/ConverterBuilderClassBuilder.kt
@@ -1,0 +1,228 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+@file:Suppress(
+    "StringLiteralDuplication"
+)
+
+package com.kotlindiscord.kord.extensions.modules.annotations.converters.builders
+
+import com.kotlindiscord.kord.extensions.modules.annotations.containsAny
+import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
+import org.koin.core.component.KoinComponent
+
+/**
+ * Builder class that itself builds converter builder classes. Meta, I know.
+ *
+ * This is a fairly messy class containing a string builder, but what can you do?
+ */
+public class ConverterBuilderClassBuilder : KoinComponent {
+    /** Comment to prepend to the class definition. **/
+    public var comment: String? = null
+
+    /** Converter name - eg, `"${name}ConverterBuilder"`. **/
+    public lateinit var name: String
+
+    /**
+     * Converter class - class that should be instantiated to construct the converter.
+     *
+     * Technically could be a function, but this would be playing with fire.
+     */
+    public lateinit var converterClass: String
+
+    /** Argument type, the type the user should ultimately be given after parsing. **/
+    public lateinit var argumentType: String
+
+    /** Builder generic params, if any. Omit the `<>`. **/
+    public var builderGeneric: String? = null
+
+    internal val builderArguments: MutableList<String> = mutableListOf()
+    internal val builderArgumentNames: MutableList<String> = mutableListOf()
+
+    internal val builderFields: MutableList<String> = mutableListOf()
+    internal val builderFieldNames: MutableList<String> = mutableListOf()
+
+    internal val types: MutableSet<ConverterType> = mutableSetOf()
+
+    internal var converterType: String = ""
+    internal var builderType: String = ""
+
+    /** The ultimate result, the final string created after calling [build]. **/
+    public var result: String? = null
+        private set
+
+    /** Add a builder constructor argument. **/
+    public fun builderArg(arg: String) {
+        builderArguments.add(arg)
+        builderArgumentNames.add(arg.split(":").first().split(" ").last())
+    }
+
+    /** Add a builder field. **/
+    public fun builderField(field: String) {
+        builderFields.add(field)
+        builderFieldNames.add(field.split(":").first().split(" ").last())
+    }
+
+    /** Specify the converter types that this builder concerns. **/
+    public fun types(vararg types: ConverterType) {
+        this.types.addAll(types)
+    }
+
+    /** Build the string that contains this builder's code. It's also stored in [result]. **/
+    public fun build(): String {
+        builderType = ""
+        converterType = ""
+
+        val builder = StringBuilder()
+
+        if (comment != null) {
+            builder.append("/**\n")
+
+            comment!!.lines().forEach {
+                builder.append(" * $it\n")
+            }
+
+            builder.append(" */\n")
+        }
+
+        builder.append("public class ")
+
+        types.groupBy { it.order }.forEach { (_, entries) ->
+            if (entries.size > 1) {
+                error("Only one of the following converter types may be specified at once: ${entries.joinToString()}")
+            }
+        }
+
+        types.sortedBy { it.order }.forEach {
+            if (it.appendFragment) {
+                converterType += it.fragment
+            }
+        }
+
+        builderType = "${converterType}${name}ConverterBuilder"
+
+        builder.append(builderType)
+
+        if (builderGeneric != null) {
+            builder.append(" <$builderGeneric>")
+        }
+
+        builder.append("(")
+
+        if (builderArguments.isNotEmpty()) {
+            builder.append("\n")
+
+            builderArguments.forEach {
+                builder.append("    $it,\n")
+            }
+        }
+
+        builder.append(") : ${converterType}ConverterBuilder<$argumentType>()")
+
+        if (ConverterType.SINGLE in types && converterType.isEmpty()) {
+            converterType += "Single"
+        }
+
+        converterType += "Converter"
+
+        if (ConverterType.CHOICE in types) {
+            builder.append(", ChoiceConverterBuilder<$argumentType>")
+        }
+
+        builder.append(" {\n")
+
+        if (ConverterType.CHOICE in types) {
+            builder.append("    override val choices = mutableMapOf()\n\n")
+        }
+
+        if (builderFields.isNotEmpty()) {
+            builderFields.forEach {
+                builder.append("    $it\n")
+            }
+
+            builder.append("\n")
+        }
+
+        builder.append("    public override fun build(arguments: Arguments): $converterType<$argumentType> {\n")
+        builder.append("        return arguments.arg(\n")
+        builder.append("            displayName = name,\n")
+        builder.append("            description = description,\n")
+        builder.append("\n")
+        builder.append("            converter = $converterClass(\n")
+
+        if (!types.containsAny(ConverterType.LIST, ConverterType.COALESCING, ConverterType.DEFAULTING)) {
+            builder.append("                validator = validator,\n")
+        }
+
+        builderArgumentNames.forEach {
+            builder.append("                $it = $it,\n")
+        }
+
+        builderFieldNames.forEach {
+            builder.append("                $it = $it,\n")
+        }
+
+        builder.append("            )")
+
+        if (types.contains(ConverterType.DEFAULTING)) {
+            builder.append(".toDefaulting(\n")
+            builder.append("                defaultValue = defaultValue,\n")
+            builder.append("                outputError = !ignoreErrors,\n")
+            builder.append("                nestedValidator = validator,\n")
+            builder.append("            )")
+        } else if (types.contains(ConverterType.OPTIONAL)) {
+            builder.append(".toOptional(\n")
+            builder.append("                outputError = !ignoreErrors,\n")
+            builder.append("                nestedValidator = validator,\n")
+            builder.append("            )")
+        } else if (types.contains(ConverterType.LIST)) {
+            builder.append(".toMulti(\n")
+            builder.append("                required = !ignoreErrors,\n")
+            builder.append("                nestedValidator = validator,\n")
+            builder.append("            )")
+        }
+
+        builder.append("\n")
+        builder.append("        )\n")
+        builder.append("    }\n")
+        builder.append("}\n")
+
+        result = builder.toString()
+
+        return result!!
+    }
+}
+
+/** DSL function to easily build a converter builder class. Returns the builder. **/
+public fun builderClass(body: ConverterBuilderClassBuilder.() -> Unit): ConverterBuilderClassBuilder {
+    val builder = ConverterBuilderClassBuilder()
+
+    body(builder)
+
+    builder.build()
+
+    return builder
+}
+
+/** @suppress TODO: Remove this later, it's for testing **/
+public fun main() {
+    println(
+        builderClass {
+            name = "Enum"
+            converterClass = "EnumConverter"
+            argumentType = "E"
+
+            builderGeneric = "E: Enum<E>"
+
+            builderArg("public var getter: suspend (String) -> E?")
+
+            builderField("public lateinit var typeName: String")
+            builderField("public var bundle: String? = null")
+
+            types(ConverterType.COALESCING)
+        }.result
+    )
+}

--- a/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/builders/ConverterBuilderFunctionBuilder.kt
+++ b/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/builders/ConverterBuilderFunctionBuilder.kt
@@ -27,6 +27,9 @@ public class ConverterBuilderFunctionBuilder : KoinComponent {
     /** Builder function generic arguments. Omit the `<>`. **/
     public var functionGeneric: String? = null
 
+    /** Extra generic bounds to place after `where` in the function signature. **/
+    public var whereSuffix: String? = null
+
     internal val builderArguments: MutableList<String> = mutableListOf()
 
     /** Argument function name, `"Arguments.$name"`. **/
@@ -88,7 +91,13 @@ public class ConverterBuilderFunctionBuilder : KoinComponent {
 
         builder.append(".() -> Unit\n")
 
-        builder.append("): $converterType<$argumentType> {\n")
+        builder.append("): $converterType<$argumentType>")
+
+        if (whereSuffix != null) {
+            builder.append(" where $whereSuffix")
+        }
+
+        builder.append(" {\n")
         builder.append("    val builder = $builderType")
 
         if (splitBuilderGeneric != null) {

--- a/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/builders/ConverterBuilderFunctionBuilder.kt
+++ b/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/builders/ConverterBuilderFunctionBuilder.kt
@@ -1,0 +1,149 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+@file:Suppress(
+    "StringLiteralDuplication"
+)
+
+package com.kotlindiscord.kord.extensions.modules.annotations.converters.builders
+
+import org.koin.core.component.KoinComponent
+
+/**
+ * Builder class that itself builds converter builder functions. Not quite as meta as the other one.
+ *
+ * This is a fairly messy class containing a string builder, but what can you do?
+ */
+public class ConverterBuilderFunctionBuilder : KoinComponent {
+    /** Comment to prepend to the function definition. **/
+    public var comment: String? = null
+
+    /** Builder function generic arguments. Omit the `<>`. **/
+    public var generic: String? = null
+
+    /** Builder class generic arguments. Omit the `<>`. **/
+    public var builderGeneric: String? = null
+
+    internal val builderArguments: MutableList<String> = mutableListOf()
+
+    /** Argument function name, `"Arguments.$name"`. **/
+    public lateinit var name: String
+
+    /** Builder class type, used as a receiver. **/
+    public lateinit var builderType: String
+
+    /** Argument type, the type the user should ultimately be given after parsing. **/
+    public lateinit var argumentType: String
+
+    /** Basic converter type, returned by the function. **/
+    public lateinit var converterType: String
+
+    /**
+     * Add a builder constructor argument. `name = value` only, please.
+     *
+     * If this is a lambda, you can refer to the outer `builder` to get values provided by the user.
+     */
+    public fun builderArg(arg: String): Boolean =
+        builderArguments.add(arg)
+
+    /** Build the string that contains this builder's code. **/
+    public fun build(): String {
+        val builder = StringBuilder()
+
+        if (comment != null) {
+            builder.append("/**\n")
+
+            comment!!.lines().forEach {
+                builder.append(" * $it\n")
+            }
+
+            builder.append(" */\n")
+        }
+
+        builder.append("public ")
+
+        if (generic != null) {
+            builder.append("inline ")
+        }
+
+        builder.append("fun ")
+
+        if (generic != null) {
+            builder.append("<reified $generic> ")
+        }
+
+        builder.append("Arguments.$name(\n")
+
+        builder.append("    body: $builderType")
+
+        val splitBuilderGeneric = builderGeneric?.split(",")
+            ?.joinToString { it.split(":").first() }
+
+        if (splitBuilderGeneric != null) {
+            builder.append("<$splitBuilderGeneric>")
+        }
+
+        builder.append(".() -> Unit\n")
+
+        builder.append("): $converterType<$argumentType> {\n")
+        builder.append("    val builder = $builderType")
+
+        if (splitBuilderGeneric != null) {
+            builder.append("<$splitBuilderGeneric>")
+        }
+
+        builder.append("(")
+
+        if (builderArguments.isNotEmpty()) {
+            builder.append("\n")
+
+            builderArguments.forEach {
+                builder.append("        $it,\n")
+            }
+
+            builder.append("    ")
+        }
+
+        builder.append(")\n")
+
+        builder.append("    \n")
+        builder.append("    body(builder)\n")
+        builder.append("    \n")
+        builder.append("    builder.validateArgument()\n")
+        builder.append("    \n")
+        builder.append("    return builder.build(this)\n")
+        builder.append("}")
+
+        return builder.toString()
+    }
+}
+
+/** DSL function to easily build a converter builder class. Returns a String. **/
+public fun builderFunction(body: ConverterBuilderFunctionBuilder.() -> Unit): String {
+    val builder = ConverterBuilderFunctionBuilder()
+
+    body(builder)
+
+    return builder.build()
+}
+
+/** @suppress TODO: Remove this later, it's for testing **/
+public fun main() {
+    println(
+        builderFunction {
+            generic = "E: Enum<E>"
+            builderGeneric = "E: Enum<E>"
+
+            argumentType = "E"
+            converterType = "SingleConverter"
+
+            name = "enum"
+            builderType = "EnumConverterBuilder"
+
+            builderArg("getter = { getEnum(it) }")
+        }
+    )
+}

--- a/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/builders/ConverterBuilderFunctionBuilder.kt
+++ b/annotation-processor/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/builders/ConverterBuilderFunctionBuilder.kt
@@ -21,11 +21,11 @@ public class ConverterBuilderFunctionBuilder : KoinComponent {
     /** Comment to prepend to the function definition. **/
     public var comment: String? = null
 
-    /** Builder function generic arguments. Omit the `<>`. **/
-    public var generic: String? = null
-
     /** Builder class generic arguments. Omit the `<>`. **/
     public var builderGeneric: String? = null
+
+    /** Builder function generic arguments. Omit the `<>`. **/
+    public var functionGeneric: String? = null
 
     internal val builderArguments: MutableList<String> = mutableListOf()
 
@@ -65,14 +65,14 @@ public class ConverterBuilderFunctionBuilder : KoinComponent {
 
         builder.append("public ")
 
-        if (generic != null) {
+        if (functionGeneric != null) {
             builder.append("inline ")
         }
 
         builder.append("fun ")
 
-        if (generic != null) {
-            builder.append("<reified $generic> ")
+        if (functionGeneric != null) {
+            builder.append("<reified $functionGeneric> ")
         }
 
         builder.append("Arguments.$name(\n")
@@ -134,7 +134,7 @@ public fun builderFunction(body: ConverterBuilderFunctionBuilder.() -> Unit): St
 public fun main() {
     println(
         builderFunction {
-            generic = "E: Enum<E>"
+            functionGeneric = "E: Enum<E>"
             builderGeneric = "E: Enum<E>"
 
             argumentType = "E"

--- a/annotation-processor/src/main/resources/templates/defaultingConverter.kt.jte
+++ b/annotation-processor/src/main/resources/templates/defaultingConverter.kt.jte
@@ -1,0 +1,46 @@
+@import java.util.ArrayList
+@import java.util.List
+@import com.google.devtools.ksp.symbol.KSClassDeclaration
+@import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterProcessor
+
+@param KSClassDeclaration classDeclaration
+@param String name
+@param String typeParam
+@param ArrayList<String> extraArguments
+@param String generic
+
+@param String packageName
+@param String qualifiedClassName
+@param String qualifiedTypeName
+
+@param String capitalisedConverterName
+
+@param List<String> imports
+
+@tag.base(packageName, qualifiedClassName, qualifiedTypeName, imports)
+
+
+/**
+ * Creates a defaulting ${name} converter, for single arguments.
+ *
+ * \@param defaultValue Default value to use if no argument was provided.
+ * \@see ${classDeclaration.getSimpleName().asString()}
+ */
+public fun Arguments.defaulting${ConverterProcessor.Companion.capitalize(name)}(
+    displayName: String,
+    description: String,
+    defaultValue: Boolean,
+    required: Boolean = false,
+    validator: Validator<Boolean> = null,
+): DefaultingConverter<${typeParam}> =
+    arg(
+        displayName = displayName,
+        description = description,
+
+        converter = BooleanConverter()
+            .toDefaulting(
+                defaultValue = defaultValue,
+                outputError = required,
+                nestedValidator = validator,
+            )
+    )

--- a/annotation-processor/src/main/resources/templates/tags/base.kt.jte
+++ b/annotation-processor/src/main/resources/templates/tags/base.kt.jte
@@ -1,0 +1,39 @@
+<%--
+ This Source Code Form is subject to the terms of the Mozilla Public
+ License, v. 2.0. If a copy of the MPL was not distributed with this
+ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--%>
+
+@import java.util.List
+
+@param String packageName
+@param String qualifiedClassName
+@param String qualifiedTypeName
+
+@param List<String> imports
+
+@file:OptIn(
+    KordPreview::class,
+    ConverterToDefaulting::class,
+    ConverterToMulti::class,
+    ConverterToOptional::class
+)
+
+package ${packageName}
+
+// Original converter class, for safety
+import ${qualifiedClassName}
+
+// Imports that all converters need
+import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.Arguments
+import dev.kord.common.annotation.KordPreview
+
+@if(qualifiedTypeName != null)
+    // Converter type param
+    import ${qualifiedTypeName}
+@endif
+
+@for(String importName: imports)
+    import ${importName}
+@endfor

--- a/annotations/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/Converter.kt
+++ b/annotations/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/Converter.kt
@@ -7,28 +7,33 @@
 package com.kotlindiscord.kord.extensions.modules.annotations.converters
 
 /**
- * Mark the class as a converter class, allowing converter functions to be generated.
+ * Mark the class as a converter class, allowing converter builders and their functions to be generated.
  *
  * @property names Converter names, used to generate the functions. Multiple names will generate multiple sets of
  * functions - surprise surprise.
 
- * @property types Converter function types to generate.
+ * @property types Converter types to generate builders and functions for.
  * @property imports Extra imports required for generated code to be valid.
  *
- * @property arguments Extra argument lines to add to every generated function, without the trailing comma. These will
- * be added as extra function arguments, and they'll also be passed into the class as matching named arguments- so
- * your converter's constructor must have the same names!
+ * @property builderConstructorArguments Arguments to add to the builder's constructor, if any.
+ * @property builderGeneric Generic typevar that the builder should take, if any.
+ * @property builderFields Extra fields to add to the builder, if any. Use `lateinit var` for required values.
  *
- * @property generic Generic typevar to be made accessible in your converter functions. The function will be marked
- * inline and the typevar will be reified - if you have custom callable arguments, you'll probably need to mark them
- * `noinline`. Typevars should be specified without the angle brackets - eg, "T : Any".
+ * @property functionBuilderArguments Arguments to pass into the builder's constructor, if any.
+ * @property functionGeneric Generic typevar that the builder should take, if any. Will be `reified`.
  */
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.CLASS)
 public annotation class Converter(
     public vararg val names: String,
+
     public val types: Array<ConverterType>,
     public val imports: Array<String> = [],
-    public val arguments: Array<String> = [],
-    public val generic: String = ""
+
+    public val builderConstructorArguments: Array<String> = [],
+    public val builderGeneric: String = "",
+    public val builderFields: Array<String> = [],
+
+    public val functionBuilderArguments: Array<String> = [],
+    public val functionGeneric: String = "",
 )

--- a/annotations/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/Converter.kt
+++ b/annotations/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/Converter.kt
@@ -15,10 +15,13 @@ package com.kotlindiscord.kord.extensions.modules.annotations.converters
  * @property types Converter types to generate builders and functions for.
  * @property imports Extra imports required for generated code to be valid.
  *
- * @property builderConstructorArguments Arguments to add to the builder's constructor, if any.
+ * @property builderConstructorArguments Arguments to add to the builder's constructor, if any. Prefix with "!!" to
+ * stop the argument from being passed into the converter.
+ *
  * @property builderGeneric Generic typevar that the builder should take, if any.
  * @property builderFields Extra fields to add to the builder, if any. Use `lateinit var` for required values.
  * @property builderInitStatements Extra lines of code to add to the builder's `init { }` block.
+ * @property builderExtraStatements Extra lines of code to add to the builder, after the fields.
  * @property builderSuffixedWhere Extra generic bounds to place after `where` in the builder's signature.
  *
  * @property functionBuilderArguments Arguments to pass into the builder's constructor, if any.
@@ -39,6 +42,7 @@ public annotation class Converter(
     public val builderSuffixedWhere: String = "",
 
     public val builderInitStatements: Array<String> = [],
+    public val builderExtraStatements: Array<String> = [],
 
     public val functionBuilderArguments: Array<String> = [],
     public val functionGeneric: String = "",

--- a/annotations/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/Converter.kt
+++ b/annotations/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/Converter.kt
@@ -18,9 +18,12 @@ package com.kotlindiscord.kord.extensions.modules.annotations.converters
  * @property builderConstructorArguments Arguments to add to the builder's constructor, if any.
  * @property builderGeneric Generic typevar that the builder should take, if any.
  * @property builderFields Extra fields to add to the builder, if any. Use `lateinit var` for required values.
+ * @property builderInitStatements Extra lines of code to add to the builder's `init { }` block.
+ * @property builderSuffixedWhere Extra generic bounds to place after `where` in the builder's signature.
  *
  * @property functionBuilderArguments Arguments to pass into the builder's constructor, if any.
  * @property functionGeneric Generic typevar that the builder should take, if any. Will be `reified`.
+ * @property functionSuffixedWhere Extra generic bounds to place after `where` in the function's signature.
  */
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.CLASS)
@@ -33,7 +36,11 @@ public annotation class Converter(
     public val builderConstructorArguments: Array<String> = [],
     public val builderGeneric: String = "",
     public val builderFields: Array<String> = [],
+    public val builderSuffixedWhere: String = "",
+
+    public val builderInitStatements: Array<String> = [],
 
     public val functionBuilderArguments: Array<String> = [],
     public val functionGeneric: String = "",
+    public val functionSuffixedWhere: String = "",
 )

--- a/annotations/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/Converter.kt
+++ b/annotations/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/Converter.kt
@@ -9,7 +9,7 @@ package com.kotlindiscord.kord.extensions.modules.annotations.converters
 /**
  * Mark the class as a converter class, allowing converter functions to be generated.
  *
- * @property names Converter names, used to generate the functions. Multiple names will generate multiple set of
+ * @property names Converter names, used to generate the functions. Multiple names will generate multiple sets of
  * functions - surprise surprise.
 
  * @property types Converter function types to generate.

--- a/annotations/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/ConverterType.kt
+++ b/annotations/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/annotations/converters/ConverterType.kt
@@ -8,12 +8,39 @@ package com.kotlindiscord.kord.extensions.modules.annotations.converters
 
 /**
  * Enum representing different types of converter functions.
+ *
+ * @property fragment String fragment to add to the converter type name
+ * @property order Order of types - for naming order and compatibility
+ * @property appendFragment Whether to append the string fragment, or ignore it
  */
-public enum class ConverterType {
-    CHOICE,
-    COALESCING,
-    DEFAULTING,
-    LIST,
-    OPTIONAL,
-    SINGLE,
+public enum class ConverterType(
+    public val fragment: String,
+    public val order: Int,
+    public val appendFragment: Boolean = true
+) {
+    DEFAULTING("Defaulting", 0),
+    LIST("List", 0),
+    OPTIONAL("Optional", 0),
+
+    COALESCING("Coalescing", 1),
+    SINGLE("", 1),
+
+    CHOICE("Choice", 2, false);
+
+    public companion object {
+        /** Given the `.name` or `.simpleName` of a converter type, get the relevant enum entry. **/
+        public fun fromName(name: String): ConverterType? =
+            when (name) {
+                DEFAULTING.name -> DEFAULTING
+                LIST.name -> LIST
+                OPTIONAL.name -> OPTIONAL
+
+                COALESCING.name -> COALESCING
+                SINGLE.name -> SINGLE
+
+                CHOICE.name -> CHOICE
+
+                else -> null
+            }
+    }
 }

--- a/buildSrc/src/main/kotlin/published-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/published-module.gradle.kts
@@ -2,7 +2,6 @@ import org.gradle.api.publish.maven.MavenPublication
 
 plugins {
     `maven-publish`
-    signing
 }
 
 val sourceJar: Task by tasks.getting
@@ -37,9 +36,4 @@ publishing {
             artifact(javadocJar)
         }
     }
-}
-
-signing {
-    useGpgCmd()
-    sign(publishing.publications["maven"])
 }

--- a/extra-modules/extra-mappings/build.gradle.kts
+++ b/extra-modules/extra-mappings/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `published-module`
     `dokka-module`
     `disable-explicit-api-mode`
+    `ksp-module`
 }
 
 repositories {
@@ -52,6 +53,9 @@ dependencies {
     testImplementation(libs.logback)
 
     implementation(project(":kord-extensions"))
+    implementation(project(":annotations"))
+
+    ksp(project(":annotation-processor"))
 }
 
 group = "com.kotlindiscord.kord.extensions"

--- a/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/arguments/HashedMojangArguments.kt
+++ b/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/arguments/HashedMojangArguments.kt
@@ -13,9 +13,10 @@ import me.shedaniel.linkie.namespaces.MojangHashedNamespace
 /** Arguments for hashed Mojang mappings lookup commands. **/
 @Suppress("UndocumentedPublicProperty")
 class HashedMojangArguments : MappingWithChannelArguments(MojangHashedNamespace) {
-    override val channel by optionalEnumChoice<Channels>(
-        displayName = "channel",
-        description = "Mappings channel to use for this query",
+    override val channel by optionalEnumChoice<Channels> {
+        name = "channel"
+        description = "Mappings channel to use for this query"
+
         typeName = "official/snapshot"
-    )
+    }
 }

--- a/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/arguments/MappingArguments.kt
+++ b/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/arguments/MappingArguments.kt
@@ -21,10 +21,10 @@ open class MappingArguments(val namespace: Namespace) : Arguments() {
         description = "Name to query mappings for"
     }
 
-    val version by optionalMappingsVersion(
-        "version",
-        "Minecraft version to use for this query",
-        true,
-        namespace
-    )
+    val version by optionalMappingsVersion {
+        name = "version"
+        description = "Minecraft version to use for this query"
+
+        namespace(namespace)
+    }
 }

--- a/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/arguments/MappingArguments.kt
+++ b/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/arguments/MappingArguments.kt
@@ -16,7 +16,10 @@ import me.shedaniel.linkie.Namespace
  */
 @Suppress("UndocumentedPublicProperty")
 open class MappingArguments(val namespace: Namespace) : Arguments() {
-    val query by string("query", "Name to query mappings for")
+    val query by string {
+        name = "query"
+        description = "Name to query mappings for"
+    }
 
     val version by optionalMappingsVersion(
         "version",

--- a/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/arguments/MappingConversionArguments.kt
+++ b/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/arguments/MappingConversionArguments.kt
@@ -16,14 +16,37 @@ import com.kotlindiscord.kord.extensions.commands.converters.impl.string
  */
 @Suppress("UndocumentedPublicProperty")
 class MappingConversionArguments(enabledNamespaces: Map<String, String>) : Arguments() {
-    val query by string("query", "Name to query mappings for")
-    val inputNamespace by stringChoice("input", "The namespace to convert from", enabledNamespaces)
-    val outputNamespace by stringChoice("output", "The namespace to convert to", enabledNamespaces)
-    val version by optionalString(
-        "version",
-        "Minecraft version to use for this query",
-    )
+    val query by string {
+        name = "query"
+        description = "Name to query mappings for"
+    }
 
-    val inputChannel by optionalString("inputChannel", "The mappings channel to use for input")
-    val outputChannel by optionalString("outputChannel", "The mappings channel to use for output")
+    val inputNamespace by stringChoice {
+        name = "input"
+        description = "The namespace to convert from"
+
+        choices(enabledNamespaces)
+    }
+
+    val outputNamespace by stringChoice {
+        name = "output"
+        description = "The namespace to convert to"
+
+        choices(enabledNamespaces)
+    }
+
+    val version by optionalString {
+        name = "version"
+        description = "Minecraft version to use for this query"
+    }
+
+    val inputChannel by optionalString {
+        name = "inputChannel"
+        description = "The mappings channel to use for input"
+    }
+
+    val outputChannel by optionalString {
+        name = "outputChannel"
+        description = "The mappings channel to use for output"
+    }
 }

--- a/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/arguments/MojangArguments.kt
+++ b/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/arguments/MojangArguments.kt
@@ -13,9 +13,10 @@ import me.shedaniel.linkie.namespaces.MojangNamespace
 /** Arguments for Mojang mappings lookup commands. **/
 @Suppress("UndocumentedPublicProperty")
 class MojangArguments : MappingWithChannelArguments(MojangNamespace) {
-    override val channel by optionalEnumChoice<Channels>(
-        displayName = "channel",
-        description = "Mappings channel to use for this query",
+    override val channel by optionalEnumChoice<Channels> {
+        name = "channel"
+        description = "Mappings channel to use for this query"
+
         typeName = "official/snapshot"
-    )
+    }
 }

--- a/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/arguments/YarnWithPatchworkArguments.kt
+++ b/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/arguments/YarnWithPatchworkArguments.kt
@@ -13,10 +13,10 @@ import me.shedaniel.linkie.namespaces.YarnNamespace
 /** Arguments for Yarn mappings lookup commands when the Patchwork channel is enabled. **/
 @Suppress("UndocumentedPublicProperty")
 class YarnWithPatchworkArguments : MappingWithChannelArguments(YarnNamespace) {
-    override val channel by optionalEnumChoice<YarnChannels>(
-        displayName = "channel",
-        description = "Mappings channel to use for this query",
+    override val channel by optionalEnumChoice<YarnChannels> {
+        name = "channel"
+        description = "Mappings channel to use for this query"
 
         typeName = "official/snapshot/patchwork"
-    )
+    }
 }

--- a/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/arguments/YarnWithoutPatchworkArguments.kt
+++ b/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/arguments/YarnWithoutPatchworkArguments.kt
@@ -13,10 +13,10 @@ import me.shedaniel.linkie.namespaces.YarnNamespace
 /** Arguments for Yarn mappings lookup commands when the Patchwork channel is disabled. **/
 @Suppress("UndocumentedPublicProperty")
 class YarnWithoutPatchworkArguments : MappingWithChannelArguments(YarnNamespace) {
-    override val channel by optionalEnumChoice<Channels>(
-        displayName = "channel",
-        description = "Mappings channel to use for this query",
+    override val channel by optionalEnumChoice<Channels> {
+        name = "channel"
+        description = "Mappings channel to use for this query"
 
         typeName = "official/snapshot"
-    )
+    }
 }

--- a/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/converters/MappingsVersionConverter.kt
+++ b/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/converters/MappingsVersionConverter.kt
@@ -10,11 +10,12 @@ package com.kotlindiscord.kord.extensions.modules.extra.mappings.converters
 
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
-import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.CommandContext
 import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
 import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
 import com.kotlindiscord.kord.extensions.commands.converters.Validator
+import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
+import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser
 import dev.kord.common.annotation.KordPreview
 import dev.kord.core.entity.interaction.OptionValue
@@ -26,6 +27,19 @@ import me.shedaniel.linkie.Namespace
 /**
  * Argument converter for [MappingsContainer] objects based on mappings versions.
  */
+@Converter(
+    "mappingsVersion",
+    types = [ConverterType.SINGLE, ConverterType.OPTIONAL],
+    imports = ["me.shedaniel.linkie.Namespace"],
+
+    builderFields = ["public lateinit var namespaceGetter: suspend () -> Namespace"],
+    builderExtraStatements = [
+        "/** Convenience function for setting the namespace getter to a specific namespace. **/",
+        "public fun namespace(namespace: Namespace) {",
+        "    namespaceGetter = { namespace }",
+        "}",
+    ]
+)
 class MappingsVersionConverter(
     private val namespaceGetter: suspend () -> Namespace,
     override var validator: Validator<MappingsContainer> = null
@@ -71,18 +85,3 @@ class MappingsVersionConverter(
         throw DiscordRelayedException("Invalid ${namespace.id} version: `$optionValue`")
     }
 }
-
-/** Optional mappings version converter; see KordEx bundled functions for more info. **/
-fun Arguments.optionalMappingsVersion(
-    displayName: String,
-    description: String,
-    outputError: Boolean = false,
-    namespace: Namespace,
-    validator: Validator<MappingsContainer?> = null
-) =
-    arg(
-        displayName,
-        description,
-        MappingsVersionConverter({ namespace })
-            .toOptional(outputError = outputError, nestedValidator = validator)
-    )

--- a/extra-modules/extra-phishing/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/phishing/PhishingExtension.kt
+++ b/extra-modules/extra-phishing/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/phishing/PhishingExtension.kt
@@ -381,8 +381,13 @@ class PhishingExtension(private val settings: ExtPhishingBuilder) : Extension() 
     /** Arguments class for domain-relevant commands. **/
     inner class DomainArgs : Arguments() {
         /** Targeted domain string. **/
-        val domain by string("domain", "Domain to check") {
-            failIf("Please provide the domain name only, without the protocol or a path.") { "/" in value }
+        val domain by string {
+            name = "domain"
+            description = "Domain to check"
+
+            validate {
+                failIf("Please provide the domain name only, without the protocol or a path.") { "/" in value }
+            }
         }
     }
 }

--- a/extra-modules/extra-phishing/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/phishing/PhishingExtension.kt
+++ b/extra-modules/extra-phishing/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/phishing/PhishingExtension.kt
@@ -10,7 +10,6 @@
 package com.kotlindiscord.kord.extensions.modules.extra.phishing
 
 import com.kotlindiscord.kord.extensions.DISCORD_RED
-import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.checks.hasPermission
 import com.kotlindiscord.kord.extensions.checks.isNotBot
 import com.kotlindiscord.kord.extensions.commands.Arguments
@@ -382,10 +381,8 @@ class PhishingExtension(private val settings: ExtPhishingBuilder) : Extension() 
     /** Arguments class for domain-relevant commands. **/
     inner class DomainArgs : Arguments() {
         /** Targeted domain string. **/
-        val domain by string("domain", "Domain to check") { _, value ->
-            if ("/" in value) {
-                throw DiscordRelayedException("Please provide the domain name only, without the protocol or a path.")
-            }
+        val domain by string("domain", "Domain to check") {
+            failIf("Please provide the domain name only, without the protocol or a path.") { "/" in value }
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ kotlin.incremental = true
 
 ksp.incremental = false
 
-projectVersion = 1.5.1-SNAPSHOT
+projectVersion = 1.5.2-SNAPSHOT
 
 #dokka will run out of memory with the default meta space
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=1024m

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/Exceptions.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/Exceptions.kt
@@ -9,6 +9,7 @@ package com.kotlindiscord.kord.extensions
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.chat.ChatCommand
+import com.kotlindiscord.kord.extensions.commands.converters.builders.ConverterBuilder
 import com.kotlindiscord.kord.extensions.events.EventHandler
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.parser.StringParser
@@ -18,6 +19,20 @@ import kotlin.reflect.KClass
  * A base class for all custom exceptions in our bot framework.
  */
 public open class ExtensionsException : Exception()
+
+/**
+ * Exception thrown when a converter builder hasn't been set up properly.
+ *
+ * @property builder Builder that didn't validate
+ * @property reason Reason for the validation failure
+ **/
+public class InvalidArgumentException(
+    public val builder: ConverterBuilder<*>,
+    public val reason: String
+) : ExtensionsException() {
+    override fun toString(): String =
+        "Invalid argument: $builder ($reason)"
+}
 
 /**
  * Thrown when an attempt to load an [Extension] fails.
@@ -36,7 +51,7 @@ public class InvalidExtensionException(
             ""
         }
 
-        return "Invalid extension class: ${clazz.qualifiedName} $formattedReason"
+        return "Invalid extension class: ${clazz.qualifiedName}$formattedReason"
     }
 }
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/Arguments.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/Arguments.kt
@@ -72,7 +72,7 @@ public open class Arguments {
      *
      * @return Argument converter to use as a delegate.
      */
-    public fun <R : Any?> arg(
+    public fun <R : Any> arg(
         displayName: String,
         description: String,
         converter: OptionalConverter<R>
@@ -156,7 +156,7 @@ public open class Arguments {
      *
      * @return Argument converter to use as a delegate.
      */
-    public fun <R : Any?> arg(
+    public fun <R : Any> arg(
         displayName: String,
         description: String,
         converter: OptionalCoalescingConverter<R>

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/Arguments.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/Arguments.kt
@@ -83,7 +83,7 @@ public open class Arguments {
     }
 
     /**
-     * Add a [MultiConverter] argument to this set of arguments.
+     * Add a [ListConverter] argument to this set of arguments.
      *
      * This is typically used indirectly, via an extension function that wraps it. It returns the converter, which
      * is intended to be used as a property delegate.
@@ -96,8 +96,8 @@ public open class Arguments {
     public fun <R : Any> arg(
         displayName: String,
         description: String,
-        converter: MultiConverter<R>
-    ): MultiConverter<R> {
+        converter: ListConverter<R>
+    ): ListConverter<R> {
         args.add(Argument(displayName, description, converter))
 
         return converter

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/converters/impl/EnumChoiceConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/converters/impl/EnumChoiceConverter.kt
@@ -100,7 +100,7 @@ public inline fun <reified T> Arguments.optionalEnumChoice(
     typeName: String,
     noinline validator: Validator<T?> = null,
     bundle: String? = null,
-): OptionalConverter<T?> where T : Enum<T>, T : ChoiceEnum = arg(
+): OptionalConverter<T> where T : Enum<T>, T : ChoiceEnum = arg(
     displayName,
     description,
     EnumChoiceConverter<T>(typeName, ::getEnum, enumValues(), bundle = bundle)

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/converters/impl/EnumChoiceConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/converters/impl/EnumChoiceConverter.kt
@@ -14,11 +14,15 @@
 package com.kotlindiscord.kord.extensions.commands.application.slash.converters.impl
 
 import com.kotlindiscord.kord.extensions.commands.Argument
-import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.CommandContext
 import com.kotlindiscord.kord.extensions.commands.application.slash.converters.ChoiceConverter
 import com.kotlindiscord.kord.extensions.commands.application.slash.converters.ChoiceEnum
-import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToMulti
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
+import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
+import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser
 import dev.kord.common.annotation.KordPreview
 import dev.kord.core.entity.interaction.OptionValue
@@ -30,14 +34,48 @@ import dev.kord.rest.builder.interaction.StringChoiceBuilder
  *
  * All enums used for this must implement the [ChoiceEnum] interface.
  */
+@Converter(
+    "enum",
+
+    types = [ConverterType.SINGLE, ConverterType.DEFAULTING, ConverterType.OPTIONAL, ConverterType.CHOICE],
+    imports = [
+        "com.kotlindiscord.kord.extensions.commands.converters.impl.getEnum",
+        "com.kotlindiscord.kord.extensions.commands.application.slash.converters.ChoiceEnum"
+    ],
+
+    builderGeneric = "E",
+    builderConstructorArguments = [
+        "public var getter: suspend (String) -> E?",
+        "!! argMap: Map<String, E>",
+    ],
+
+    builderFields = [
+        "public lateinit var typeName: String",
+        "public var bundle: String? = null"
+    ],
+
+    builderInitStatements = [
+        "choices(argMap)"
+    ],
+
+    builderSuffixedWhere = "E : Enum<E>, E : ChoiceEnum",
+
+    functionGeneric = "E",
+    functionBuilderArguments = [
+        "getter = { getEnum(it) }",
+        "argMap = enumValues<E>().associateBy { it.readableName }",
+    ],
+
+    functionSuffixedWhere = "E : Enum<E>, E : ChoiceEnum"
+)
 @OptIn(KordPreview::class)
 public class EnumChoiceConverter<E>(
     typeName: String,
     private val getter: suspend (String) -> E?,
-    choices: Array<E>,
+    choices: Map<String, E>,
     override var validator: Validator<E> = null,
     override val bundle: String? = null,
-) : ChoiceConverter<E>(choices.associateBy { it.readableName }) where E : Enum<E>, E : ChoiceEnum {
+) : ChoiceConverter<E>(choices) where E : Enum<E>, E : ChoiceEnum {
     override val signatureTypeString: String = typeName
 
     override suspend fun parse(parser: StringParser?, context: CommandContext, named: String?): Boolean {
@@ -71,60 +109,6 @@ public class EnumChoiceConverter<E>(
         return true
     }
 }
-
-/**
- * Create an enum choice argument converter, for a defined set of single arguments.
- *
- * @see EnumChoiceConverter
- */
-public inline fun <reified T> Arguments.enumChoice(
-    displayName: String,
-    description: String,
-    typeName: String,
-    noinline validator: Validator<T> = null,
-    bundle: String? = null,
-): SingleConverter<T> where T : Enum<T>, T : ChoiceEnum = arg(
-    displayName,
-    description,
-    EnumChoiceConverter(typeName, ::getEnum, enumValues(), validator, bundle = bundle)
-)
-
-/**
- * Create an optional enum choice argument converter, for a defined set of single arguments.
- *
- * @see EnumChoiceConverter
- */
-public inline fun <reified T> Arguments.optionalEnumChoice(
-    displayName: String,
-    description: String,
-    typeName: String,
-    noinline validator: Validator<T?> = null,
-    bundle: String? = null,
-): OptionalConverter<T> where T : Enum<T>, T : ChoiceEnum = arg(
-    displayName,
-    description,
-    EnumChoiceConverter<T>(typeName, ::getEnum, enumValues(), bundle = bundle)
-        .toOptional(nestedValidator = validator)
-)
-
-/**
- * Create a defaulting enum choice argument converter, for a defined set of single arguments.
- *
- * @see EnumChoiceConverter
- */
-public inline fun <reified T> Arguments.defaultingEnumChoice(
-    displayName: String,
-    description: String,
-    typeName: String,
-    defaultValue: T,
-    noinline validator: Validator<T> = null,
-    bundle: String? = null,
-): DefaultingConverter<T> where T : Enum<T>, T : ChoiceEnum = arg(
-    displayName,
-    description,
-    EnumChoiceConverter<T>(typeName, ::getEnum, enumValues(), bundle = bundle)
-        .toDefaulting(defaultValue, nestedValidator = validator)
-)
 
 /**
  * The default enum value getter - matches enums based on a case-insensitive string comparison with the name.

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/converters/impl/EnumChoiceConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/converters/impl/EnumChoiceConverter.kt
@@ -111,9 +111,10 @@ public class EnumChoiceConverter<E>(
 }
 
 /**
- * The default enum value getter - matches enums based on a case-insensitive string comparison with the name.
+ * The default choice enum value getter - matches choice enums via a case-insensitive string comparison with the names.
  */
-public inline fun <reified T : Enum<T>> getEnum(arg: String): T? =
-    enumValues<T>().firstOrNull {
+public inline fun <reified E> getEnum(arg: String): E? where E : Enum<E>, E : ChoiceEnum =
+    enumValues<E>().firstOrNull {
+        it.readableName.equals(arg, true) ||
         it.name.equals(arg, true)
     }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/converters/impl/NumberChoiceConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/converters/impl/NumberChoiceConverter.kt
@@ -40,11 +40,10 @@ private const val DEFAULT_RADIX = 10
     "number",
 
     types = [ConverterType.CHOICE, ConverterType.DEFAULTING, ConverterType.OPTIONAL, ConverterType.SINGLE],
-    arguments = ["radix: Int = $DEFAULT_RADIX"]
+    builderFields = ["public var radix: Int = $DEFAULT_RADIX"]
 )
 @OptIn(KordPreview::class)
-public
-class NumberChoiceConverter(
+public class NumberChoiceConverter(
     private val radix: Int = DEFAULT_RADIX,
     choices: Map<String, Long>,
     override var validator: Validator<Long> = null

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/chat/ChatCommandParser.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/chat/ChatCommandParser.kt
@@ -300,7 +300,7 @@ public open class ChatCommandParser : KoinComponent {
                     }
                 }
 
-                is MultiConverter<*> -> try {
+                is ListConverter<*> -> try {
                     val parsedCount = if (hasKwargs) {
                         converter.parse(parser, context, kwValue!!)
                     } else {
@@ -748,7 +748,7 @@ public open class ChatCommandParser : KoinComponent {
                 }
             }
 
-            if (it.converter is MultiConverter<*>) {
+            if (it.converter is ListConverter<*>) {
                 signature += "..."
             }
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/CoalescingConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/CoalescingConverter.kt
@@ -9,6 +9,7 @@
 package com.kotlindiscord.kord.extensions.commands.converters
 
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
+import com.kotlindiscord.kord.extensions.commands.converters.builders.CoalescingConverterBuilder
 import dev.kord.common.annotation.KordPreview
 
 /**
@@ -40,6 +41,19 @@ public abstract class CoalescingConverter<T : Any>(
      * This should be set by the converter during the course of the [parse] function.
      */
     public override lateinit var parsed: T
+
+    /** Access to the converter builder, perhaps a bit more hacky than it should be but whatever. **/
+    public open lateinit var builder: CoalescingConverterBuilder<T>
+
+    /** @suppress Internal function used by converter builders. **/
+    public open fun withBuilder(
+        builder: CoalescingConverterBuilder<T>
+    ): CoalescingConverter<T> {
+        this.builder = builder
+        this.genericBuilder = builder
+
+        return this
+    }
 
     /**
      * Wrap this coalescing converter with a [CoalescingToOptionalConverter], which is a special converter that will

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/CoalescingConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/CoalescingConverter.kt
@@ -70,7 +70,7 @@ public abstract class CoalescingConverter<T : Any>(
         errorTypeString: String? = null,
         outputError: Boolean = false,
         nestedValidator: Validator<T?> = null
-    ): OptionalCoalescingConverter<T?> = CoalescingToOptionalConverter(
+    ): OptionalCoalescingConverter<T> = CoalescingToOptionalConverter(
         this,
         signatureTypeString,
         showTypeInSignature,

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/CoalescingToOptionalConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/CoalescingToOptionalConverter.kt
@@ -37,7 +37,7 @@ public class CoalescingToOptionalConverter<T : Any>(
     outputError: Boolean = false,
 
     override var validator: Validator<T?> = null
-) : OptionalCoalescingConverter<T?>(outputError) {
+) : OptionalCoalescingConverter<T>(outputError) {
     override val signatureTypeString: String = newSignatureTypeString ?: coalescingConverter.signatureTypeString
     override val showTypeInSignature: Boolean = newShowTypeInSignature ?: coalescingConverter.showTypeInSignature
     override val errorTypeString: String? = newErrorTypeString ?: coalescingConverter.errorTypeString

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/Converter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/Converter.kt
@@ -13,6 +13,7 @@ import com.kotlindiscord.kord.extensions.ExtensibleBot
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.CommandContext
+import com.kotlindiscord.kord.extensions.commands.converters.builders.ValidationContext
 import com.kotlindiscord.kord.extensions.parser.StringParser
 import dev.kord.common.annotation.KordPreview
 import dev.kord.core.Kord
@@ -102,7 +103,13 @@ public abstract class Converter<InputType : Any?, OutputType : Any?, NamedInputT
 
     /** Call the validator lambda, if one was provided. **/
     public open suspend fun validate(context: CommandContext) {
-        validator?.let { it(context, this.argumentObj, parsed) }
+        validator?.let { actualValidator ->
+            val validationContext = ValidationContext(parsed, context)
+
+            actualValidator.invoke(validationContext)
+
+            validationContext.throwIfFailed()
+        }
     }
 
     /**

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/Converter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/Converter.kt
@@ -13,6 +13,7 @@ import com.kotlindiscord.kord.extensions.ExtensibleBot
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.CommandContext
+import com.kotlindiscord.kord.extensions.commands.converters.builders.ConverterBuilder
 import com.kotlindiscord.kord.extensions.commands.converters.builders.ValidationContext
 import com.kotlindiscord.kord.extensions.parser.StringParser
 import dev.kord.common.annotation.KordPreview
@@ -41,6 +42,9 @@ import kotlin.reflect.KProperty
 public abstract class Converter<InputType : Any?, OutputType : Any?, NamedInputType : Any, ResultType : Any>(
     public open val required: Boolean = true,
 ) : KoinComponent {
+    /** This is pretty hacky, but there aren't many better options. **/
+    internal lateinit var genericBuilder: ConverterBuilder<OutputType>
+
     /** Current instance of the bot. **/
     public open val bot: ExtensibleBot by inject()
 
@@ -87,7 +91,11 @@ public abstract class Converter<InputType : Any?, OutputType : Any?, NamedInputT
 
     /** For delegation, retrieve the parsed value if it's been set, or null if it hasn't. **/
     public operator fun getValue(thisRef: Arguments, property: KProperty<*>): OutputType =
-        parsed
+        if (genericBuilder.mutator != null) {
+            genericBuilder.mutator!!(parsed)
+        } else {
+            parsed
+        }
 
     /**
      * Given a Throwable encountered during the [parse] function, return a human-readable string to display on Discord.

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/Converter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/Converter.kt
@@ -143,7 +143,7 @@ public abstract class Converter<InputType : Any?, OutputType : Any?, NamedInputT
      * vowel.
      */
     public open suspend fun getErrorString(context: CommandContext): String = when (this) {
-        is MultiConverter<*> -> context.translate(errorTypeString ?: signatureTypeString)
+        is ListConverter<*> -> context.translate(errorTypeString ?: signatureTypeString)
         is CoalescingConverter<*> -> context.translate(errorTypeString ?: signatureTypeString)
 
         else -> if (errorTypeString != null) {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/DefaultingCoalescingConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/DefaultingCoalescingConverter.kt
@@ -8,6 +8,7 @@
 
 package com.kotlindiscord.kord.extensions.commands.converters
 
+import com.kotlindiscord.kord.extensions.commands.converters.builders.DefaultingCoalescingConverterBuilder
 import dev.kord.common.annotation.KordPreview
 
 /**
@@ -36,4 +37,17 @@ public abstract class DefaultingCoalescingConverter<T : Any>(
      * This should be set by the converter during the course of the [parse] function.
      */
     public override var parsed: T = defaultValue
+
+    /** Access to the converter builder, perhaps a bit more hacky than it should be but whatever. **/
+    public open lateinit var builder: DefaultingCoalescingConverterBuilder<T>
+
+    /** @suppress Internal function used by converter builders. **/
+    public open fun withBuilder(
+        builder: DefaultingCoalescingConverterBuilder<T>
+    ): DefaultingCoalescingConverter<T> {
+        this.builder = builder
+        this.genericBuilder = builder
+
+        return this
+    }
 }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/DefaultingConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/DefaultingConverter.kt
@@ -8,6 +8,7 @@
 
 package com.kotlindiscord.kord.extensions.commands.converters
 
+import com.kotlindiscord.kord.extensions.commands.converters.builders.DefaultingConverterBuilder
 import dev.kord.common.annotation.KordPreview
 
 /**
@@ -32,4 +33,17 @@ public abstract class DefaultingConverter<T : Any>(
      * This should be set by the converter during the course of the [parse] function.
      */
     public override var parsed: T = defaultValue
+
+    /** Access to the converter builder, perhaps a bit more hacky than it should be but whatever. **/
+    public open lateinit var builder: DefaultingConverterBuilder<T>
+
+    /** @suppress Internal function used by converter builders. **/
+    public open fun withBuilder(
+        builder: DefaultingConverterBuilder<T>
+    ): DefaultingConverter<T> {
+        this.builder = builder
+        this.genericBuilder = builder
+
+        return this
+    }
 }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/ListConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/ListConverter.kt
@@ -8,6 +8,7 @@
 
 package com.kotlindiscord.kord.extensions.commands.converters
 
+import com.kotlindiscord.kord.extensions.commands.converters.builders.ListConverterBuilder
 import dev.kord.common.annotation.KordPreview
 
 /**
@@ -32,4 +33,17 @@ public abstract class ListConverter<T : Any>(
      * This should be set by the converter during the course of the [parse] function.
      */
     public override var parsed: List<T> = listOf()
+
+    /** Access to the converter builder, perhaps a bit more hacky than it should be but whatever. **/
+    public open lateinit var builder: ListConverterBuilder<T>
+
+    /** @suppress Internal function used by converter builders. **/
+    public open fun withBuilder(
+        builder: ListConverterBuilder<T>
+    ): ListConverter<T> {
+        this.builder = builder
+        this.genericBuilder = builder
+
+        return this
+    }
 }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/ListConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/ListConverter.kt
@@ -13,16 +13,16 @@ import dev.kord.common.annotation.KordPreview
 /**
  * Abstract base class for a multi converter.
  *
- * Multi converters take a list of multiple arguments, consuming as many arguments as it can to produce a list
+ * List converters take a list of multiple arguments, consuming as many arguments as it can to produce a list
  * of resulting values. Upon reaching an argument that can't be consumed, the converter stores everything it could
  * convert and tells the parser how many arguments it managed to consume. The parser will continue processing the
  * unused arguments, passing them to the remaining converters.
  *
- * You can create a multi converter of your own by extending this class.
+ * You can create a list converter of your own by extending this class.
  *
  * @property validator Validation lambda, which may throw a DiscordRelayedException if required.
  */
-public abstract class MultiConverter<T : Any>(
+public abstract class ListConverter<T : Any>(
     required: Boolean = true,
     override var validator: Validator<List<T>> = null
 ) : Converter<List<T>, List<T>, List<String>, Int>(required) {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/OptionalCoalescingConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/OptionalCoalescingConverter.kt
@@ -8,6 +8,7 @@
 
 package com.kotlindiscord.kord.extensions.commands.converters
 
+import com.kotlindiscord.kord.extensions.commands.converters.builders.OptionalCoalescingConverterBuilder
 import dev.kord.common.annotation.KordPreview
 
 /**
@@ -25,7 +26,7 @@ import dev.kord.common.annotation.KordPreview
  * @property outputError Whether the argument parser should output parsing errors on invalid arguments.
  * @property validator Validation lambda, which may throw a DiscordRelayedException if required.
  */
-public abstract class OptionalCoalescingConverter<T : Any?>(
+public abstract class OptionalCoalescingConverter<T : Any>(
     public val outputError: Boolean = false,
     override var validator: Validator<T?> = null
 ) : Converter<List<T>, T?, List<String>, Int>(false), SlashCommandConverter {
@@ -35,4 +36,17 @@ public abstract class OptionalCoalescingConverter<T : Any?>(
      * This should be set by the converter during the course of the [parse] function.
      */
     public override var parsed: T? = null
+
+    /** Access to the converter builder, perhaps a bit more hacky than it should be but whatever. **/
+    public open lateinit var builder: OptionalCoalescingConverterBuilder<T>
+
+    /** @suppress Internal function used by converter builders. **/
+    public open fun withBuilder(
+        builder: OptionalCoalescingConverterBuilder<T>
+    ): OptionalCoalescingConverter<T> {
+        this.builder = builder
+        this.genericBuilder = builder
+
+        return this
+    }
 }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/OptionalConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/OptionalConverter.kt
@@ -8,6 +8,7 @@
 
 package com.kotlindiscord.kord.extensions.commands.converters
 
+import com.kotlindiscord.kord.extensions.commands.converters.builders.OptionalConverterBuilder
 import dev.kord.common.annotation.KordPreview
 
 /**
@@ -18,7 +19,7 @@ import dev.kord.common.annotation.KordPreview
  * @property outputError Whether the argument parser should output parsing errors on invalid arguments.
  * @property validator Validation lambda, which may throw a DiscordRelayedException if required.
  */
-public abstract class OptionalConverter<T : Any?>(
+public abstract class OptionalConverter<T : Any>(
     public val outputError: Boolean = false,
     override var validator: Validator<T?> = null
 ) : Converter<T, T?, String, Boolean>(false), SlashCommandConverter {
@@ -28,4 +29,17 @@ public abstract class OptionalConverter<T : Any?>(
      * This should be set by the converter during the course of the [parse] function.
      */
     public override var parsed: T? = null
+
+    /** Access to the converter builder, perhaps a bit more hacky than it should be but whatever. **/
+    public open lateinit var builder: OptionalConverterBuilder<T>
+
+    /** @suppress Internal function used by converter builders. **/
+    public open fun withBuilder(
+        builder: OptionalConverterBuilder<T>
+    ): OptionalConverter<T> {
+        this.builder = builder
+        this.genericBuilder = builder
+
+        return this
+    }
 }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/SingleConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/SingleConverter.kt
@@ -8,6 +8,7 @@
 
 package com.kotlindiscord.kord.extensions.commands.converters
 
+import com.kotlindiscord.kord.extensions.commands.converters.builders.ConverterBuilder
 import dev.kord.common.annotation.KordPreview
 
 /**
@@ -32,6 +33,19 @@ public abstract class SingleConverter<T : Any>(
      * This should be set by the converter during the course of the [parse] function.
      */
     public override lateinit var parsed: T
+
+    /** Access to the converter builder, perhaps a bit more hacky than it should be but whatever. **/
+    public open lateinit var builder: ConverterBuilder<T>
+
+    /** @suppress Internal function used by converter builders. **/
+    public open fun withBuilder(
+        builder: ConverterBuilder<T>
+    ): SingleConverter<T> {
+        this.builder = builder
+        this.genericBuilder = builder
+
+        return this
+    }
 
     /**
      * Wrap this single converter with a [SingleToListConverter], which is a special converter that will act like a

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/SingleConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/SingleConverter.kt
@@ -17,7 +17,7 @@ import dev.kord.common.annotation.KordPreview
  * are always required.
  *
  * You can convert a [SingleConverter] instance to a defaulting, optional or multi converter
- * using [toDefaulting]. [toMulti] or [toOptional] respectively.
+ * using [toDefaulting]. [toList] or [toOptional] respectively.
  *
  * You can create a single converter of your own by extending this class.
  *
@@ -34,8 +34,8 @@ public abstract class SingleConverter<T : Any>(
     public override lateinit var parsed: T
 
     /**
-     * Wrap this single converter with a [SingleToMultiConverter], which is a special converter that will act like a
-     * [MultiConverter] using the same logic of this converter.
+     * Wrap this single converter with a [SingleToListConverter], which is a special converter that will act like a
+     * [ListConverter] using the same logic of this converter.
      *
      * Your converter should be designed with this pattern in mind. If that's not possible, please override this
      * function and throw an exception in the body.
@@ -54,13 +54,13 @@ public abstract class SingleConverter<T : Any>(
      * provides.
      */
     @ConverterToMulti
-    public open fun toMulti(
+    public open fun toList(
         required: Boolean = true,
         signatureTypeString: String? = null,
         showTypeInSignature: Boolean? = null,
         errorTypeString: String? = null,
         nestedValidator: Validator<List<T>> = null
-    ): MultiConverter<T> = SingleToMultiConverter(
+    ): ListConverter<T> = SingleToListConverter(
         required,
         this,
         signatureTypeString,
@@ -97,7 +97,7 @@ public abstract class SingleConverter<T : Any>(
         errorTypeString: String? = null,
         outputError: Boolean = false,
         nestedValidator: Validator<T?> = null
-    ): OptionalConverter<T?> = SingleToOptionalConverter(
+    ): OptionalConverter<T> = SingleToOptionalConverter(
         this,
         signatureTypeString,
         showTypeInSignature,

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/SingleToListConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/SingleToListConverter.kt
@@ -12,10 +12,10 @@ import com.kotlindiscord.kord.extensions.commands.CommandContext
 import com.kotlindiscord.kord.extensions.parser.StringParser
 
 /**
- * A special [MultiConverter] that wraps a [SingleConverter], effectively turning it into a list-handling converter
+ * A special [ListConverter] that wraps a [SingleConverter], effectively turning it into a list-handling converter
  * with the same logic.
  *
- * The behaviours specified in [MultiConverter] also apply to this converter, so it's worth reading about it.
+ * The behaviours specified in [ListConverter] also apply to this converter, so it's worth reading about it.
  *
  * @param singleConverter The [SingleConverter] to wrap.
  *
@@ -24,7 +24,7 @@ import com.kotlindiscord.kord.extensions.parser.StringParser
  * [singleConverter].
  * @param newErrorTypeString An optional error type string to override the one set in [singleConverter].
  */
-public class SingleToMultiConverter<T : Any>(
+public class SingleToListConverter<T : Any>(
     required: Boolean = true,
     public val singleConverter: SingleConverter<T>,
 
@@ -33,7 +33,7 @@ public class SingleToMultiConverter<T : Any>(
     newErrorTypeString: String? = null,
 
     override var validator: Validator<List<T>> = null
-) : MultiConverter<T>(required) {
+) : ListConverter<T>(required) {
     override val signatureTypeString: String = newSignatureTypeString ?: singleConverter.signatureTypeString
     override val showTypeInSignature: Boolean = newShowTypeInSignature ?: singleConverter.showTypeInSignature
     override val errorTypeString: String? = newErrorTypeString ?: singleConverter.errorTypeString

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/SingleToOptionalConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/SingleToOptionalConverter.kt
@@ -36,7 +36,7 @@ public class SingleToOptionalConverter<T : Any>(
     outputError: Boolean = false,
 
     override var validator: Validator<T?> = null
-) : OptionalConverter<T?>(outputError) {
+) : OptionalConverter<T>(outputError) {
     override val signatureTypeString: String = newSignatureTypeString ?: singleConverter.signatureTypeString
     override val showTypeInSignature: Boolean = newShowTypeInSignature ?: singleConverter.showTypeInSignature
     override val errorTypeString: String? = newErrorTypeString ?: singleConverter.errorTypeString

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/_Types.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/_Types.kt
@@ -8,8 +8,10 @@
 
 package com.kotlindiscord.kord.extensions.commands.converters
 
-import com.kotlindiscord.kord.extensions.commands.Argument
-import com.kotlindiscord.kord.extensions.commands.CommandContext
+import com.kotlindiscord.kord.extensions.commands.converters.builders.ValidationContext
 
 /** Types alias representing a validator callable. Keeps things relatively maintainable. **/
-public typealias Validator<T> = (suspend CommandContext.(arg: Argument<*>, value: T) -> Unit)?
+public typealias Validator<T> = (suspend ValidationContext<T>.() -> Unit)?
+
+/** Types alias representing a mutator callable. Keeps things relatively maintainable. **/
+public typealias Mutator<T> = (suspend (T) -> T)?

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/_Types.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/_Types.kt
@@ -13,5 +13,6 @@ import com.kotlindiscord.kord.extensions.commands.converters.builders.Validation
 /** Types alias representing a validator callable. Keeps things relatively maintainable. **/
 public typealias Validator<T> = (suspend ValidationContext<T>.() -> Unit)?
 
-/** Types alias representing a mutator callable. Keeps things relatively maintainable. **/
-public typealias Mutator<T> = (suspend (T) -> T)?
+// /** Types alias representing a mutator callable. Keeps things relatively maintainable. **/
+// public typealias Mutator<T> = (suspend (T) -> T)?
+// // This can't easily be implemented given the current converter and parsing model, we'll have to come back to it

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/_Types.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/_Types.kt
@@ -13,6 +13,5 @@ import com.kotlindiscord.kord.extensions.commands.converters.builders.Validation
 /** Types alias representing a validator callable. Keeps things relatively maintainable. **/
 public typealias Validator<T> = (suspend ValidationContext<T>.() -> Unit)?
 
-// /** Types alias representing a mutator callable. Keeps things relatively maintainable. **/
-// public typealias Mutator<T> = (suspend (T) -> T)?
-// // This can't easily be implemented given the current converter and parsing model, we'll have to come back to it
+ /** Types alias representing a mutator callable. Keeps things relatively maintainable. **/
+ public typealias Mutator<T> = ((T) -> T)?

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/ChoiceConverterBuilder.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/ChoiceConverterBuilder.kt
@@ -9,10 +9,15 @@ package com.kotlindiscord.kord.extensions.commands.converters.builders
 /** Converter builder for choice converters. **/
 public interface ChoiceConverterBuilder<T> {
     /** List of possible choices, if any. **/
-    public val choices: MutableMap<String, T>
+    public var choices: MutableMap<String, T>
 
     /** Add a choice to the list of possible choices. **/
     public fun choice(key: String, value: T) {
         choices[key] = value
+    }
+
+    /** Add a choice to the list of possible choices. **/
+    public fun choices(all: Map<String, T>) {
+        choices = all.toMutableMap()
     }
 }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/ChoiceConverterBuilder.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/ChoiceConverterBuilder.kt
@@ -1,0 +1,18 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.kotlindiscord.kord.extensions.commands.converters.builders
+
+/** Converter builder for choice converters. **/
+public interface ChoiceConverterBuilder<T> {
+    /** List of possible choices, if any. **/
+    public val choices: MutableMap<String, T>
+
+    /** Add a choice to the list of possible choices. **/
+    public fun choice(key: String, value: T) {
+        choices[key] = value
+    }
+}

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/CoalescingConverterBuilder.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/CoalescingConverterBuilder.kt
@@ -1,0 +1,10 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.kotlindiscord.kord.extensions.commands.converters.builders
+
+/** Converter builder for coalescing converters. **/
+public abstract class CoalescingConverterBuilder<T> : ConverterBuilder<T>()

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/ConverterBuilder.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/ConverterBuilder.kt
@@ -10,7 +10,6 @@ import com.kotlindiscord.kord.extensions.InvalidArgumentException
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.CommandContext
 import com.kotlindiscord.kord.extensions.commands.converters.Converter
-import com.kotlindiscord.kord.extensions.commands.converters.Mutator
 import com.kotlindiscord.kord.extensions.commands.converters.Validator
 
 /** Base abstract class for all converter builders. **/
@@ -24,19 +23,12 @@ public abstract class ConverterBuilder<T> {
     /** Validator, used for argument validation. **/
     protected open var validator: Validator<T> = null
 
-    /** Mutator, used to mutate the parsed value after the fact. **/
-    protected open var mutator: Mutator<T> = null
-
+    // This can't easily be implemented given the current converter and parsing model, we'll have to come back to it
     // public abstract suspend fun autoComplete()
 
     /** Register the validator for this converter, allowing you to validate the final value. **/
     public open fun validate(body: Validator<T>) {
         validator = body
-    }
-
-    /** Register the mutator for this converter, allowing you to mutate and replace the final value. **/
-    public open fun mutate(body: Mutator<T>) {
-        mutator = body
     }
 
     /** Using the data in this builder, create a converter and apply it to an [Arguments] object. **/

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/ConverterBuilder.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/ConverterBuilder.kt
@@ -10,6 +10,7 @@ import com.kotlindiscord.kord.extensions.InvalidArgumentException
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.CommandContext
 import com.kotlindiscord.kord.extensions.commands.converters.Converter
+import com.kotlindiscord.kord.extensions.commands.converters.Mutator
 import com.kotlindiscord.kord.extensions.commands.converters.Validator
 
 /** Base abstract class for all converter builders. **/
@@ -20,11 +21,18 @@ public abstract class ConverterBuilder<T> {
     /** Converter description. Required. **/
     public open lateinit var description: String
 
+    /** Mutator, used to mutate the parsed value before it's presented. **/
+    public open var mutator: Mutator<T> = null
+
     /** Validator, used for argument validation. **/
     protected open var validator: Validator<T> = null
 
-    // This can't easily be implemented given the current converter and parsing model, we'll have to come back to it
     // public abstract suspend fun autoComplete()
+
+    /** Register the mutator for this converter, allowing you to modify the final value. **/
+    public open fun mutate(body: Mutator<T>) {
+        mutator = body
+    }
 
     /** Register the validator for this converter, allowing you to validate the final value. **/
     public open fun validate(body: Validator<T>) {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/ConverterBuilder.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/ConverterBuilder.kt
@@ -1,0 +1,65 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.kotlindiscord.kord.extensions.commands.converters.builders
+
+import com.kotlindiscord.kord.extensions.InvalidArgumentException
+import com.kotlindiscord.kord.extensions.commands.Arguments
+import com.kotlindiscord.kord.extensions.commands.CommandContext
+import com.kotlindiscord.kord.extensions.commands.converters.Converter
+import com.kotlindiscord.kord.extensions.commands.converters.Mutator
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
+
+/** Base abstract class for all converter builders. **/
+public abstract class ConverterBuilder<T> {
+    /** Converter display name. Required. **/
+    public open lateinit var name: String
+
+    /** Converter description. Required. **/
+    public open lateinit var description: String
+
+    /** Validator, used for argument validation. **/
+    protected open var validator: Validator<T> = null
+
+    /** Mutator, used to mutate the parsed value after the fact. **/
+    protected open var mutator: Mutator<T> = null
+
+    // public abstract suspend fun autoComplete()
+
+    /** Register the validator for this converter, allowing you to validate the final value. **/
+    public open fun validate(body: Validator<T>) {
+        validator = body
+    }
+
+    /** Register the mutator for this converter, allowing you to mutate and replace the final value. **/
+    public open fun mutate(body: Mutator<T>) {
+        mutator = body
+    }
+
+    /** Using the data in this builder, create a converter and apply it to an [Arguments] object. **/
+    public abstract fun build(arguments: Arguments): Converter<*, *, *, *>
+
+    /** Validate that this builder is set up properly. **/
+    public open fun validateArgument() {
+        if (!this::name.isInitialized) {
+            throw InvalidArgumentException(this, "Required field not provided: name")
+        }
+
+        if (!this::description.isInitialized) {
+            throw InvalidArgumentException(this, "Required field not provided: description")
+        }
+    }
+
+    /** Validate that this builder's value is allowable. **/
+    public open suspend fun validateValue(commandContext: CommandContext, value: T) {
+        if (validator != null) {
+            val context = ValidationContext(value, commandContext)
+
+            validator?.invoke(context)
+            context.throwIfFailed()
+        }
+    }
+}

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/DefaultingCoalescingConverterBuilder.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/DefaultingCoalescingConverterBuilder.kt
@@ -1,0 +1,26 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.kotlindiscord.kord.extensions.commands.converters.builders
+
+import com.kotlindiscord.kord.extensions.InvalidArgumentException
+
+/** Converter builder for defaulting coalescing converters. **/
+public abstract class DefaultingCoalescingConverterBuilder<T : Any> : CoalescingConverterBuilder<T>() {
+    /** Whether to ignore parsing errors when a value is provided. **/
+    public var ignoreErrors: Boolean = false
+
+    /** Value to use when none is provided, or when there's a parsing error and [ignoreErrors] is `true`. **/
+    public open lateinit var defaultValue: T
+
+    override fun validateArgument() {
+        super.validateArgument()
+
+        if (!this::defaultValue.isInitialized) {
+            throw InvalidArgumentException(this, "Required field not provided: defaultValue")
+        }
+    }
+}

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/DefaultingConverterBuilder.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/DefaultingConverterBuilder.kt
@@ -1,0 +1,26 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.kotlindiscord.kord.extensions.commands.converters.builders
+
+import com.kotlindiscord.kord.extensions.InvalidArgumentException
+
+/** Converter builder for defaulting converters. **/
+public abstract class DefaultingConverterBuilder<T : Any> : ConverterBuilder<T>() {
+    /** Whether to ignore parsing errors when a value is provided. **/
+    public var ignoreErrors: Boolean = false
+
+    /** Value to use when none is provided, or when there's a parsing error and [ignoreErrors] is `true`. **/
+    public open lateinit var defaultValue: T
+
+    override fun validateArgument() {
+        super.validateArgument()
+
+        if (!this::defaultValue.isInitialized) {
+            throw InvalidArgumentException(this, "Required field not provided: defaultValue")
+        }
+    }
+}

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/ListConverterBuilder.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/ListConverterBuilder.kt
@@ -1,0 +1,13 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.kotlindiscord.kord.extensions.commands.converters.builders
+
+/** Converter builder for list converters. **/
+public abstract class ListConverterBuilder<T : Any> : ConverterBuilder<List<T>>() {
+    /** Whether to ignore parsing errors when no values have been parsed out. **/
+    public var ignoreErrors: Boolean = true
+}

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/OptionalCoalescingConverterBuilder.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/OptionalCoalescingConverterBuilder.kt
@@ -1,0 +1,13 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.kotlindiscord.kord.extensions.commands.converters.builders
+
+/** Converter builder for optional coalescing converters. **/
+public abstract class OptionalCoalescingConverterBuilder<T : Any> : CoalescingConverterBuilder<T?>() {
+    /** Whether to ignore parsing errors when a value is provided. **/
+    public var ignoreErrors: Boolean = false
+}

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/OptionalConverterBuilder.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/OptionalConverterBuilder.kt
@@ -1,0 +1,13 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.kotlindiscord.kord.extensions.commands.converters.builders
+
+/** Converter builder for optional converters. **/
+public abstract class OptionalConverterBuilder<T : Any> : ConverterBuilder<T?>() {
+    /** Whether to ignore parsing errors when a value is provided. **/
+    public var ignoreErrors: Boolean = false
+}

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/ValidationContext.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/ValidationContext.kt
@@ -1,0 +1,185 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.kotlindiscord.kord.extensions.commands.converters.builders
+
+import com.kotlindiscord.kord.extensions.DiscordRelayedException
+import com.kotlindiscord.kord.extensions.commands.CommandContext
+import com.kotlindiscord.kord.extensions.i18n.TranslationsProvider
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import java.util.*
+
+/**
+ * Class representing the context for an argument validator. This allows the storage of validation steps and a message
+ * for the user.
+ *
+ * @property T TypeVar representing the current argument type
+ * @property value Value of type [T]
+ * @property context Command context that triggered this validation
+ */
+public class ValidationContext<out T>(public val value: T, public val context: CommandContext) : KoinComponent {
+    /** Translations provider. **/
+    public val translations: TranslationsProvider by inject()
+
+    /**
+     * Translation key to use for the error response message, if not the default.
+     *
+     * The string pointed to by this variable must accept one replacement value, which is the error message itself.
+     *
+     * **Note:** This *must* be a translation key. A bare string may not work, as the error response function uses
+     * the replacement functionality of the translations system.
+     */
+    public var errorResponseKey: String = "checks.responseTemplate"
+
+    /** Translation bundle used by [translate] by default and the error response translation, if not the default. **/
+    public var defaultBundle: String? = null
+
+    /** Human-readable message for the user, if any. **/
+    public var message: String? = null
+
+    /** Whether this validator has passed. **/
+    public var passed: Boolean = true
+
+    /** Mark this validator as having passed successfully. **/
+    public fun pass() {
+        this.passed = true
+    }
+
+    /** Mark this validator as having failed, optionally providing a message for the user. **/
+    public fun fail(message: String? = null) {
+        this.message = message
+        this.passed = false
+    }
+
+    /**
+     * If [value] is `true`, mark this validator as having failed, optionally providing a message for the user.
+     *
+     * Returns `true` if the validator was marked as having failed, `false` otherwise.
+     */
+    public fun failIf(value: Boolean, message: String? = null): Boolean {
+        if (value) {
+            fail(message)
+
+            return true
+        }
+
+        return false
+    }
+
+    /**
+     * If [callback] returns `true`, mark this validator as having failed, optionally providing a message for the user.
+     *
+     * Returns `true` if the validator was marked as having failed, `false` otherwise.
+     */
+    public suspend fun failIf(message: String? = null, callback: suspend () -> Boolean): Boolean =
+        failIf(callback(), message)
+
+    /**
+     * If [value] is `false`, mark this validator as having failed, optionally providing a message for the user.
+     *
+     * Returns `true` if the validator was marked as having failed, `false` otherwise.
+     */
+    public fun failIfNot(value: Boolean, message: String? = null): Boolean =
+        failIf(!value, message)
+
+    /**
+     * If [callback] returns `false`, mark this validator as having failed, optionally providing a message for the user.
+     *
+     * Returns `true` if the validator was marked as having failed, `false` otherwise.
+     */
+    public suspend fun failIfNot(message: String? = null, callback: suspend () -> Boolean): Boolean =
+        failIfNot(callback(), message)
+
+    /**
+     * If [value] is `true`, mark this validator as having passed.
+     *
+     * Returns `true` if the validator was marked as having passed, `false` otherwise.
+     */
+    public fun passIf(value: Boolean): Boolean {
+        if (value) {
+            pass()
+
+            return true
+        }
+
+        return false
+    }
+
+    /**
+     * If [callback] returns `true`, mark this validator as having passed.
+     *
+     * Returns `true` if the validator was marked as having passed, `false` otherwise.
+     */
+    public suspend fun passIf(callback: suspend () -> Boolean): Boolean =
+        passIf(callback())
+
+    /**
+     * If [value] is `true`, mark this validator as having passed.
+     *
+     * Returns `true` if the validator was marked as having passed, `false` otherwise.
+     */
+    public fun passIfNot(value: Boolean): Boolean =
+        passIf(!value)
+
+    /**
+     * If [callback] returns `true`, mark this validator as having passed.
+     *
+     * Returns `true` if the validator was marked as having passed, `false` otherwise.
+     */
+    public suspend fun passIfNot(callback: suspend () -> Boolean): Boolean =
+        passIfNot(callback())
+
+    /** Call the given block if the Boolean receiver is `true`. **/
+    public inline fun <T : Any> Boolean.whenTrue(body: () -> T?): T? {
+        if (this) {
+            return body()
+        }
+
+        return null
+    }
+
+    /** Call the given block if the Boolean receiver is `false`. **/
+    public inline fun <T : Any> Boolean.whenFalse(body: () -> T?): T? {
+        if (!this) {
+            return body()
+        }
+
+        return null
+    }
+
+    /** Quick access to translate strings using this validator context's [locale]. **/
+    public suspend fun translate(
+        key: String,
+        bundle: String? = defaultBundle,
+        replacements: Array<Any?> = arrayOf()
+    ): String =
+        translations.translate(key, context.getLocale(), bundleName = bundle, replacements = replacements)
+
+    /**
+     * If this validator has failed, throw a [DiscordRelayedException] with the translated message, if any.
+     */
+    @Throws(DiscordRelayedException::class)
+    public suspend fun throwIfFailed() {
+        if (passed.not()) {
+            if (message != null) {
+                throw DiscordRelayedException(
+                    getTranslatedMessage()!!
+                )
+            } else {
+                error("Validation failed.")
+            }
+        }
+    }
+
+    /** Get the translated validator failure message, if the validator has failed and a message was set. **/
+    public suspend fun getTranslatedMessage(): String? =
+        if (passed.not() && message != null) {
+            translate(errorResponseKey, defaultBundle, replacements = arrayOf(message))
+        } else {
+            null
+        }
+}

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/ChannelConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/ChannelConverter.kt
@@ -11,12 +11,17 @@
     FlowPreview::class,
     KordPreview::class,
 )
+
 package com.kotlindiscord.kord.extensions.commands.converters.impl
 
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.CommandContext
-import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToMulti
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
+import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/ChannelConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/ChannelConverter.kt
@@ -53,10 +53,12 @@ import kotlinx.coroutines.flow.toList
 
     types = [ConverterType.LIST, ConverterType.OPTIONAL, ConverterType.SINGLE],
     imports = ["dev.kord.common.entity.Snowflake"],
-    arguments = [
-        "requireSameGuild: Boolean = true",
-        "requiredGuild: (suspend () -> Snowflake)? = null"
-    ]
+
+    builderFields = [
+        "public var requireSameGuild: Boolean = true",
+        "public var requiredGuild: (suspend () -> Snowflake)? = null"
+    ],
+
 )
 @OptIn(KordPreview::class)
 public class ChannelConverter(

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/ColorConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/ColorConverter.kt
@@ -18,7 +18,11 @@ package com.kotlindiscord.kord.extensions.commands.converters.impl
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.CommandContext
-import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToMulti
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
+import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/DecimalConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/DecimalConverter.kt
@@ -16,7 +16,11 @@ package com.kotlindiscord.kord.extensions.commands.converters.impl
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.CommandContext
-import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToMulti
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
+import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/DurationCoalescingConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/DurationCoalescingConverter.kt
@@ -39,10 +39,10 @@ import kotlin.time.ExperimentalTime
     types = [ConverterType.COALESCING, ConverterType.DEFAULTING, ConverterType.OPTIONAL],
     imports = ["kotlinx.datetime.*"],
 
-    arguments = [
-        "longHelp: Boolean = true",
-        "positiveOnly: Boolean = true",
-        "shouldThrow: Boolean = false"
+    builderFields = [
+        "public var longHelp: Boolean = true",
+        "public var positiveOnly: Boolean = true",
+        "public var shouldThrow: Boolean = false"
     ],
 )
 @OptIn(KordPreview::class, ExperimentalTime::class)

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/DurationConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/DurationConverter.kt
@@ -37,9 +37,9 @@ import kotlin.time.ExperimentalTime
     types = [ConverterType.DEFAULTING, ConverterType.OPTIONAL, ConverterType.SINGLE],
     imports = ["kotlinx.datetime.*"],
 
-    arguments = [
-        "longHelp: Boolean = true",
-        "positiveOnly: Boolean = true"
+    builderFields = [
+        "public var longHelp: Boolean = true",
+        "public var positiveOnly: Boolean = true"
     ],
 )
 @OptIn(KordPreview::class, ExperimentalTime::class)

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/EmailConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/EmailConverter.kt
@@ -16,7 +16,11 @@ package com.kotlindiscord.kord.extensions.commands.converters.impl
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.CommandContext
-import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToMulti
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
+import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/EmojiConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/EmojiConverter.kt
@@ -16,7 +16,11 @@ package com.kotlindiscord.kord.extensions.commands.converters.impl
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.CommandContext
-import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToMulti
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
+import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/EnumConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/EnumConverter.kt
@@ -15,7 +15,11 @@ package com.kotlindiscord.kord.extensions.commands.converters.impl
 
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.CommandContext
-import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToMulti
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
+import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/EnumConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/EnumConverter.kt
@@ -44,12 +44,6 @@ import dev.kord.rest.builder.interaction.StringChoiceBuilder
     types = [ConverterType.SINGLE, ConverterType.DEFAULTING, ConverterType.OPTIONAL, ConverterType.LIST],
     imports = ["com.kotlindiscord.kord.extensions.commands.converters.impl.getEnum"],
 
-//    arguments = [
-//        "typeName: String",
-//        "noinline getter: suspend (String) -> E? = { getEnum<E>(it) }",
-//        "bundle: String? = null",
-//    ],
-
     builderGeneric = "E: Enum<E>",
     builderConstructorArguments = [
         "public var getter: suspend (String) -> E?"

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/EnumConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/EnumConverter.kt
@@ -42,13 +42,27 @@ import dev.kord.rest.builder.interaction.StringChoiceBuilder
     "enum",
 
     types = [ConverterType.SINGLE, ConverterType.DEFAULTING, ConverterType.OPTIONAL, ConverterType.LIST],
-
-    generic = "E: Enum<E>",
     imports = ["com.kotlindiscord.kord.extensions.commands.converters.impl.getEnum"],
-    arguments = [
-        "typeName: String",
-        "noinline getter: suspend (String) -> E? = { getEnum<E>(it) }",
-        "bundle: String? = null",
+
+//    arguments = [
+//        "typeName: String",
+//        "noinline getter: suspend (String) -> E? = { getEnum<E>(it) }",
+//        "bundle: String? = null",
+//    ],
+
+    builderGeneric = "E: Enum<E>",
+    builderConstructorArguments = [
+        "public var getter: suspend (String) -> E?"
+    ],
+
+    builderFields = [
+        "public lateinit var typeName: String",
+        "public var bundle: String? = null"
+    ],
+
+    functionGeneric = "E: Enum<E>",
+    functionBuilderArguments = [
+        "getter = { getEnum(it) }",
     ]
 )
 @OptIn(KordPreview::class)

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/GuildConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/GuildConverter.kt
@@ -16,7 +16,11 @@ package com.kotlindiscord.kord.extensions.commands.converters.impl
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.CommandContext
-import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToMulti
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
+import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/IntConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/IntConverter.kt
@@ -38,7 +38,7 @@ private const val DEFAULT_RADIX = 10
     "int",
 
     types = [ConverterType.DEFAULTING, ConverterType.LIST, ConverterType.OPTIONAL, ConverterType.SINGLE],
-    arguments = ["radix: Int = $DEFAULT_RADIX"]
+    builderFields = ["public var radix: Int = $DEFAULT_RADIX"]
 )
 @OptIn(KordPreview::class)
 public class IntConverter(

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/IntConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/IntConverter.kt
@@ -16,7 +16,11 @@ package com.kotlindiscord.kord.extensions.commands.converters.impl
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.CommandContext
-import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToMulti
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
+import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/LongConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/LongConverter.kt
@@ -16,7 +16,11 @@ package com.kotlindiscord.kord.extensions.commands.converters.impl
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.CommandContext
-import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToMulti
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
+import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/LongConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/LongConverter.kt
@@ -38,7 +38,7 @@ private const val DEFAULT_RADIX = 10
     "long",
 
     types = [ConverterType.DEFAULTING, ConverterType.LIST, ConverterType.OPTIONAL, ConverterType.SINGLE],
-    arguments = ["radix: Int = $DEFAULT_RADIX"]
+    builderFields = ["public var radix: Int = $DEFAULT_RADIX"]
 )
 @OptIn(KordPreview::class)
 public class LongConverter(

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/MemberConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/MemberConverter.kt
@@ -17,7 +17,11 @@ import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.CommandContext
 import com.kotlindiscord.kord.extensions.commands.chat.ChatCommandContext
-import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToMulti
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
+import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/MemberConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/MemberConverter.kt
@@ -52,9 +52,10 @@ import kotlinx.coroutines.flow.firstOrNull
 
     types = [ConverterType.LIST, ConverterType.OPTIONAL, ConverterType.SINGLE],
     imports = ["dev.kord.common.entity.Snowflake"],
-    arguments = [
-        "requiredGuild: (suspend () -> Snowflake)? = null",
-        "useReply: Boolean = true",
+
+    builderFields = [
+        "public var requiredGuild: (suspend () -> Snowflake)? = null",
+        "public var useReply: Boolean = true",
     ]
 )
 @OptIn(KordPreview::class)

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/MessageConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/MessageConverter.kt
@@ -17,7 +17,11 @@ import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.CommandContext
 import com.kotlindiscord.kord.extensions.commands.chat.ChatCommandContext
-import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToMulti
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
+import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/MessageConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/MessageConverter.kt
@@ -58,10 +58,11 @@ private val logger = KotlinLogging.logger {}
 
     types = [ConverterType.LIST, ConverterType.OPTIONAL, ConverterType.SINGLE],
     imports = ["dev.kord.common.entity.Snowflake"],
-    arguments = [
-        "requireGuild: Boolean = false",
-        "requiredGuild: (suspend () -> Snowflake)? = null",
-        "useReply: Boolean = true",
+
+    builderFields = [
+        "public var requireGuild: Boolean = false",
+        "public var requiredGuild: (suspend () -> Snowflake)? = null",
+        "public var useReply: Boolean = true",
     ]
 )
 @OptIn(KordPreview::class)

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/RegexCoalescingConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/RegexCoalescingConverter.kt
@@ -43,9 +43,9 @@ import dev.kord.rest.builder.interaction.StringChoiceBuilder
 @Converter(
     "regex",
 
-    types = [ConverterType.COALESCING, ConverterType.DEFAULTING, ConverterType.OPTIONAL, ConverterType.SINGLE],
+    types = [ConverterType.COALESCING, ConverterType.DEFAULTING, ConverterType.OPTIONAL,],
     imports = ["kotlin.text.RegexOption"],
-    arguments = ["options: Set<RegexOption> = setOf()"]
+    builderFields = ["public var options: Set<RegexOption> = setOf()"]
 )
 public class RegexCoalescingConverter(
     private val options: Set<RegexOption> = setOf(),

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/RegexCoalescingConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/RegexCoalescingConverter.kt
@@ -15,7 +15,11 @@ package com.kotlindiscord.kord.extensions.commands.converters.impl
 
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.CommandContext
-import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.converters.CoalescingConverter
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToMulti
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/RegexConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/RegexConverter.kt
@@ -34,7 +34,7 @@ import dev.kord.rest.builder.interaction.StringChoiceBuilder
  * Please note that user-provided regular expressions are not safe - they can take down your entire bot.
  *
  * As there is no way to validate individual segments of regex, the multi version of this converter
- * (via [toMulti]) will consume all remaining arguments.
+ * (via [toList]) will consume all remaining arguments.
  *
  * @param options Optional set of [RegexOption]s to pass to the regex parser.
  */
@@ -43,7 +43,7 @@ import dev.kord.rest.builder.interaction.StringChoiceBuilder
 
     types = [ConverterType.DEFAULTING, ConverterType.LIST, ConverterType.OPTIONAL, ConverterType.SINGLE],
     imports = ["kotlin.text.RegexOption"],
-    arguments = ["options: Set<RegexOption> = setOf()"]
+    builderFields = ["public var options: Set<RegexOption> = setOf()"]
 )
 @OptIn(KordPreview::class)
 public class RegexConverter(

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/RegexConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/RegexConverter.kt
@@ -15,7 +15,11 @@ package com.kotlindiscord.kord.extensions.commands.converters.impl
 
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.CommandContext
-import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToMulti
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
+import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/RoleConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/RoleConverter.kt
@@ -49,7 +49,7 @@ import kotlinx.coroutines.flow.firstOrNull
 
     types = [ConverterType.LIST, ConverterType.OPTIONAL, ConverterType.SINGLE],
     imports = ["dev.kord.common.entity.Snowflake"],
-    arguments = ["requiredGuild: (suspend () -> Snowflake)? = null"]
+    builderFields = ["public var requiredGuild: (suspend () -> Snowflake)? = null"]
 )
 @OptIn(KordPreview::class)
 public class RoleConverter(

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/RoleConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/RoleConverter.kt
@@ -16,7 +16,11 @@ package com.kotlindiscord.kord.extensions.commands.converters.impl
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.CommandContext
-import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToMulti
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
+import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/SnowflakeConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/SnowflakeConverter.kt
@@ -16,7 +16,11 @@ package com.kotlindiscord.kord.extensions.commands.converters.impl
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.CommandContext
-import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToMulti
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
+import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/StringCoalescingConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/StringCoalescingConverter.kt
@@ -15,7 +15,11 @@ package com.kotlindiscord.kord.extensions.commands.converters.impl
 
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.CommandContext
-import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.converters.CoalescingConverter
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToMulti
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/StringCoalescingConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/StringCoalescingConverter.kt
@@ -38,7 +38,7 @@ import dev.kord.rest.builder.interaction.StringChoiceBuilder
 @Converter(
     "string",
 
-    types = [ConverterType.COALESCING, ConverterType.DEFAULTING, ConverterType.OPTIONAL, ConverterType.SINGLE]
+    types = [ConverterType.COALESCING, ConverterType.DEFAULTING, ConverterType.OPTIONAL]
 )
 public class StringCoalescingConverter(
     shouldThrow: Boolean = false,

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/StringConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/StringConverter.kt
@@ -21,7 +21,7 @@ import dev.kord.rest.builder.interaction.StringChoiceBuilder
 /**
  * Coalescing argument that simply returns the argument as it was given.
  *
- * The multi version of this converter (via [toMulti]) will consume all remaining arguments.
+ * The multi version of this converter (via [toList]) will consume all remaining arguments.
  */
 @Converter(
     "string",

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/SupportedLocaleConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/SupportedLocaleConverter.kt
@@ -18,7 +18,11 @@ package com.kotlindiscord.kord.extensions.commands.converters.impl
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.CommandContext
-import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToMulti
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
+import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
 import com.kotlindiscord.kord.extensions.i18n.SupportedLocales
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/UserConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/UserConverter.kt
@@ -17,7 +17,11 @@ import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.CommandContext
 import com.kotlindiscord.kord.extensions.commands.chat.ChatCommandContext
-import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToMulti
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToOptional
+import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
 import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/UserConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/UserConverter.kt
@@ -49,9 +49,7 @@ import kotlinx.coroutines.flow.firstOrNull
     "user",
 
     types = [ConverterType.LIST, ConverterType.OPTIONAL, ConverterType.SINGLE],
-    arguments = [
-        "useReply: Boolean = true",
-    ]
+    builderFields = ["public var useReply: Boolean = true", ]
 )
 @OptIn(KordPreview::class)
 public class UserConverter(

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/extensions/impl/HelpExtension.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/extensions/impl/HelpExtension.kt
@@ -415,11 +415,16 @@ public class HelpExtension : HelpProvider, Extension() {
 
     /** Help command arguments class. **/
     public class HelpArguments : Arguments() {
+//        public val command: List<String> by stringList(
+//            "command",
+//            "extensions.help.commandArguments.command",
+//            false
+//        )
+
         /** Command to get help for. **/
-        public val command: List<String> by stringList(
-            "command",
-            "extensions.help.commandArguments.command",
-            false
-        )
+        public val command: List<String> by stringList {
+            name = "command"
+            description = "extensions.help.commandArguments.command"
+        }
     }
 }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/extensions/impl/SentryExtension.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/extensions/impl/SentryExtension.kt
@@ -10,7 +10,7 @@ package com.kotlindiscord.kord.extensions.extensions.impl
 
 import com.kotlindiscord.kord.extensions.builders.ExtensibleBotBuilder
 import com.kotlindiscord.kord.extensions.commands.Arguments
-import com.kotlindiscord.kord.extensions.commands.converters.impl.coalescedString
+import com.kotlindiscord.kord.extensions.commands.converters.impl.coalescingString
 import com.kotlindiscord.kord.extensions.commands.converters.impl.string
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.chatCommand
@@ -116,10 +116,10 @@ public class SentryExtension : Extension() {
         public val id: SentryId by sentryId("id", "extensions.sentry.arguments.id")
 
         /** Feedback message to submit to Sentry. **/
-        public val feedback: String by coalescedString(
-            "feedback",
-            "extensions.sentry.arguments.feedback"
-        )
+        public val feedback: String by coalescingString {
+            name = "feedback"
+            description = "extensions.sentry.arguments.feedback"
+        }
     }
 
     /** Arguments for the feedback command. **/
@@ -130,9 +130,9 @@ public class SentryExtension : Extension() {
         public val id: SentryId by sentryId("id", "Sentry event ID")
 
         /** Feedback message to submit to Sentry. **/
-        public val feedback: String by string(
-            "feedback",
-            "Feedback to send to the developers"
-        )
+        public val feedback: String by string {
+            name = "feedback"
+            description = "Feedback to send to the developers"
+        }
     }
 }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/sentry/Converters.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/sentry/Converters.kt
@@ -33,7 +33,7 @@ public fun Arguments.sentryId(displayName: String, description: String): SingleC
  *
  * @see SentryIdConverter
  */
-public fun Arguments.optionalSentryId(displayName: String, description: String): OptionalConverter<SentryId?> =
+public fun Arguments.optionalSentryId(displayName: String, description: String): OptionalConverter<SentryId> =
     arg(displayName, description, SentryIdConverter().toOptional())
 
 /**
@@ -45,5 +45,5 @@ public fun Arguments.sentryIdList(
     displayName: String,
     description: String,
     required: Boolean = true
-): MultiConverter<SentryId> =
-    arg(displayName, description, SentryIdConverter().toMulti(required))
+): ListConverter<SentryId> =
+    arg(displayName, description, SentryIdConverter().toList(required))

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/test.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/test.kt
@@ -58,6 +58,14 @@ public class EnumConverterBuilder<E : Enum<E>>(
             )
         )
     }
+
+    override fun validateArgument() {
+        super.validateArgument()
+
+        if (!this::typeName.isInitialized) {
+            throw InvalidArgumentException(this, "Required field not provided: typeName")
+        }
+    }
 }
 
 public inline fun <reified E : Enum<E>> Arguments.enum(

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/test.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/test.kt
@@ -1,0 +1,100 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+@file:Suppress(
+    "UndocumentedPublicClass",
+    "UndocumentedPublicFunction",
+    "UndocumentedPublicProperty",
+)  // This file will be removed later
+
+package com.kotlindiscord.kord.extensions
+
+import com.kotlindiscord.kord.extensions.commands.Arguments
+import com.kotlindiscord.kord.extensions.commands.converters.ConverterToDefaulting
+import com.kotlindiscord.kord.extensions.commands.converters.DefaultingConverter
+import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
+import com.kotlindiscord.kord.extensions.commands.converters.builders.ConverterBuilder
+import com.kotlindiscord.kord.extensions.commands.converters.builders.DefaultingConverterBuilder
+import com.kotlindiscord.kord.extensions.commands.converters.impl.BooleanConverter
+import com.kotlindiscord.kord.extensions.commands.converters.impl.EnumConverter
+import com.kotlindiscord.kord.extensions.commands.converters.impl.getEnum
+
+public class DefaultingBooleanConverterBuilder : DefaultingConverterBuilder<Boolean>() {
+    @OptIn(ConverterToDefaulting::class)
+    public override fun build(arguments: Arguments): DefaultingConverter<Boolean> {
+        return arguments.arg(
+            displayName = name,
+            description = description,
+
+            converter = BooleanConverter().toDefaulting(
+                defaultValue = defaultValue,
+                outputError = !ignoreErrors,
+                nestedValidator = validator
+            )
+        )
+    }
+}
+
+public class EnumConverterBuilder<E : Enum<E>>(
+    public var getter: suspend (String) -> E?
+) : ConverterBuilder<E>() {
+    public lateinit var typeName: String
+    public var bundle: String? = null
+
+    @OptIn(ConverterToDefaulting::class)
+    public override fun build(arguments: Arguments): SingleConverter<E> {
+        return arguments.arg(
+            displayName = name,
+            description = description,
+
+            converter = EnumConverter(
+                validator = validator,
+                typeName = typeName,
+                getter = getter,
+                bundle = bundle,
+            )
+        )
+    }
+}
+
+public inline fun <reified E : Enum<E>> Arguments.enum(
+    body: EnumConverterBuilder<E>.() -> Unit
+): SingleConverter<E> {
+    val builder = EnumConverterBuilder<E>(
+        getter = { getEnum(it) },
+    )
+
+    body(builder)
+
+    return builder.build(this)
+}
+
+public inline fun Arguments.defaultingBoolean(
+    body: DefaultingBooleanConverterBuilder.() -> Unit
+): DefaultingConverter<Boolean> {
+    val builder = DefaultingBooleanConverterBuilder()
+
+    body(builder)
+
+    return builder.build(this)
+}
+
+public class MyArgs : Arguments() {
+    public val bool: Boolean by defaultingBoolean {
+        name = "bool"
+        description = "Boolean argument, defaults to false"
+
+        defaultValue = false
+
+//        autocomplete {
+//            "True"
+//        }
+
+        validate {
+            failIf("Must set the value to `true`.") { !value }
+        }
+    }
+}

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/deltas/MessageDelta.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/deltas/MessageDelta.kt
@@ -33,7 +33,7 @@ public open class MessageDelta(
     public val mentionedUserIds: Optional<Set<Snowflake>>,
     public val mentionsEveryone: Optional<Boolean>,
     public val reactions: Optional<Set<Reaction>>,
-    public val stickers: Optional<List<MessageSticker>>
+    public val stickers: Optional<List<StickerItem>>
 ) {
     /**
      * A Set representing the values that have changes. Each value is represented by a human-readable string.

--- a/kord-extensions/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/TestExtension.kt
+++ b/kord-extensions/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/TestExtension.kt
@@ -102,7 +102,12 @@ class TestExtension : Extension() {
     }
 
     class SlashChoiceArgs : Arguments() {
-        val arg by enumChoice<TestChoiceEnum>("choice", "Enum Choice", "test")
+        val arg by enumChoice<TestChoiceEnum> {
+            name = "choice"
+            description = "Enum Choice"
+
+            typeName = "test"
+        }
     }
 
     class CoalescedArgs : Arguments() {

--- a/kord-extensions/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/TestExtension.kt
+++ b/kord-extensions/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/TestExtension.kt
@@ -41,34 +41,64 @@ class TestExtension : Extension() {
     val logger = KotlinLogging.logger {}
 
     class ColorArgs : Arguments() {
-        val color by colour("color", "Color to use for the embed")
+        val color by colour {
+            name = "color"
+            description = "Color to use for the embed"
+        }
     }
 
     class TestArgs : Arguments() {
-        val string by string("string", "String argument")
-        val enum by enum<TestEnum>("enum", "Enum argument", "test")
+        val string by string {
+            name = "string"
+            description = "String argument"
+        }
 
-        val optionalEnum by defaultingEnum(
-            displayName = "optional-enum",
-            description = "Defaulting enum argument",
-            typeName = "test",
+        val enum by enum<TestEnum> {
+            name = "enum"
+            description = "Enum argument"
+
+            typeName = "test"
+        }
+
+        val optionalEnum by defaultingEnum<TestEnum> {
+            name = "optional-enum"
+            description = "Defaulting enum argument"
+
+            typeName = "test"
             defaultValue = TestEnum.THREE
-        )
+        }
 
-        val bools by booleanList("bools", "Boolean list argument")
+        val bools by booleanList {
+            name = "bools"
+            description = "Boolean list argument"
+        }
     }
 
     class SlashArgs : Arguments() {
-        val string by string("string", "String argument")
-        val enum by enum<TestEnum>("enum", "Enum argument", "test")
-        val bool by boolean("bool", "Boolean argument")
+        val string by string {
+            name = "string"
+            description = "String argument"
+        }
 
-        val optionalEnum by defaultingEnum(
-            displayName = "optional-enum",
-            description = "Defaulting enum argument",
-            typeName = "test",
+        val enum by enum<TestEnum> {
+            name = "enum"
+            description = "Enum argument"
+
+            typeName = "test"
+        }
+
+        val bool by boolean {
+            name = "bool"
+            description = "Boolean argument"
+        }
+
+        val optionalEnum by defaultingEnum<TestEnum> {
+            name = "optional-enum"
+            description = "Defaulting enum argument"
+
+            typeName = "test"
             defaultValue = TestEnum.THREE
-        )
+        }
     }
 
     class SlashChoiceArgs : Arguments() {
@@ -76,20 +106,38 @@ class TestExtension : Extension() {
     }
 
     class CoalescedArgs : Arguments() {
-        val string by coalescedString("input", "Text to use")
-        val flag by optionalBoolean("flag", "Some kinda flag")
+        val string by coalescingString {
+            name = "input"
+            description = "Test to use"
+        }
+
+        val flag by optionalBoolean {
+            name = "flag"
+            description = "Some kinda flag"
+        }
     }
 
     class MessageArgs : Arguments() {
-        val message by message("target", "Target message")
+        val message by message {
+            name = "target"
+            description = "Target message"
+        }
     }
 
     class UserArgs : Arguments() {
-        val user by user("target", "Target user")
+        val user by user {
+            name = "target"
+            description = "Target user"
+        }
     }
 
     class OptionalDurationArgs : Arguments() {
-        val duration by optionalDuration("duration", "duration", required = true)
+        val duration by optionalDuration {
+            name = "duration"
+            description = "duration"
+
+            ignoreErrors = false
+        }
     }
 
     override suspend fun setup() {

--- a/modules/java-time/build.gradle.kts
+++ b/modules/java-time/build.gradle.kts
@@ -26,5 +26,5 @@ kordex {
 }
 
 dokkaModule {
-   moduleName.set("Kord Extensions: Java Time")
+    moduleName.set("Kord Extensions: Java Time")
 }

--- a/modules/java-time/build.gradle.kts
+++ b/modules/java-time/build.gradle.kts
@@ -9,7 +9,11 @@ plugins {
 
 dependencies {
     implementation(libs.kotlin.stdlib)
+
     implementation(project(":kord-extensions"))
+    implementation(project(":annotations"))
+
+    ksp(project(":annotation-processor"))
 
     detektPlugins(libs.detekt)
 

--- a/modules/java-time/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/java/ChronoContainer.kt
+++ b/modules/java-time/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/java/ChronoContainer.kt
@@ -201,7 +201,7 @@ public class ChronoContainer {
                 ChronoUnit.MONTHS -> values[unit] = period.months.toLong()
                 ChronoUnit.YEARS -> values[unit] = period.years.toLong()
 
-                else -> { }
+                else -> {}
             }
         }
     }
@@ -216,7 +216,7 @@ public class ChronoContainer {
                 ChronoUnit.MINUTES -> values[unit] = duration.toMinutesPart().toLong()
                 ChronoUnit.HOURS -> values[unit] = duration.toHoursPart().toLong()
 
-                else -> { }
+                else -> {}
             }
         }
     }
@@ -231,7 +231,7 @@ public class ChronoContainer {
                 ChronoUnit.MONTHS -> values[unit] = period.months.toLong()
                 ChronoUnit.YEARS -> values[unit] = period.years.toLong()
 
-                else -> { }
+                else -> {}
             }
         }
     }

--- a/modules/java-time/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/java/J8DurationCoalescingConverter.kt
+++ b/modules/java-time/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/java/J8DurationCoalescingConverter.kt
@@ -243,7 +243,7 @@ public fun Arguments.optionalCoalescedJ8Duration(
     longHelp: Boolean = true,
     outputError: Boolean = false,
     validator: Validator<ChronoContainer?> = null,
-): OptionalCoalescingConverter<ChronoContainer?> =
+): OptionalCoalescingConverter<ChronoContainer> =
     arg(
         displayName,
         description,

--- a/modules/java-time/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/java/J8DurationCoalescingConverter.kt
+++ b/modules/java-time/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/java/J8DurationCoalescingConverter.kt
@@ -15,10 +15,11 @@ package com.kotlindiscord.kord.extensions.modules.time.java
 
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
-import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.CommandContext
 import com.kotlindiscord.kord.extensions.commands.converters.*
 import com.kotlindiscord.kord.extensions.i18n.EMPTY_VALUE_STRING
+import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
+import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser
 import com.kotlindiscord.kord.extensions.parsers.DurationParserException
 import com.kotlindiscord.kord.extensions.parsers.InvalidTimeUnitException
@@ -42,6 +43,17 @@ import java.time.LocalDateTime
  * @see coalescedDuration
  * @see parseDurationJ8
  */
+@Converter(
+    names = ["j8Duration"],
+    types = [ConverterType.COALESCING, ConverterType.DEFAULTING, ConverterType.OPTIONAL],
+    imports = ["java.time.*"],
+
+    builderFields = [
+        "public var longHelp: Boolean = true",
+        "public var positiveOnly: Boolean = true",
+        "public var shouldThrow: Boolean = true"
+    ],
+)
 public class J8DurationCoalescingConverter(
     public val longHelp: Boolean = true,
     public val positiveOnly: Boolean = true,
@@ -206,69 +218,3 @@ public class J8DurationCoalescingConverter(
         return true
     }
 }
-
-/**
- * Create a coalescing Java 8 Duration converter.
- *
- * @see J8DurationCoalescingConverter
- */
-public fun Arguments.coalescedJ8Duration(
-    displayName: String,
-    description: String,
-    requirePositive: Boolean = true,
-    longHelp: Boolean = true,
-    shouldThrow: Boolean = false,
-    validator: Validator<ChronoContainer> = null,
-): CoalescingConverter<ChronoContainer> =
-    arg(
-        displayName,
-        description,
-        J8DurationCoalescingConverter(
-            longHelp = longHelp,
-            shouldThrow = shouldThrow,
-            positiveOnly = requirePositive,
-            validator = validator
-        )
-    )
-
-/**
- * Create an optional coalescing Java 8 Duration converter.
- *
- * @see J8DurationCoalescingConverter
- */
-public fun Arguments.optionalCoalescedJ8Duration(
-    displayName: String,
-    description: String,
-    requirePositive: Boolean = true,
-    longHelp: Boolean = true,
-    outputError: Boolean = false,
-    validator: Validator<ChronoContainer?> = null,
-): OptionalCoalescingConverter<ChronoContainer> =
-    arg(
-        displayName,
-        description,
-
-        J8DurationCoalescingConverter(longHelp = longHelp, shouldThrow = outputError, positiveOnly = requirePositive)
-            .toOptional(outputError = outputError, nestedValidator = validator)
-    )
-
-/**
- * Create a defaulting coalescing Java 8 Duration converter.
- *
- * @see J8DurationCoalescingConverter
- */
-public fun Arguments.defaultingCoalescedJ8Duration(
-    displayName: String,
-    description: String,
-    defaultValue: ChronoContainer,
-    requirePositive: Boolean = true,
-    longHelp: Boolean = true,
-    shouldThrow: Boolean = false,
-    validator: Validator<ChronoContainer> = null,
-): DefaultingCoalescingConverter<ChronoContainer> =
-    arg(
-        displayName,
-        description,
-        J8DurationCoalescingConverter(longHelp = longHelp, shouldThrow = shouldThrow, positiveOnly = requirePositive)
-            .toDefaulting(defaultValue, nestedValidator = validator)
-    )

--- a/modules/java-time/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/java/J8DurationConverter.kt
+++ b/modules/java-time/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/java/J8DurationConverter.kt
@@ -15,9 +15,10 @@ package com.kotlindiscord.kord.extensions.modules.time.java
 
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
-import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.CommandContext
 import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
+import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser
 import com.kotlindiscord.kord.extensions.parsers.DurationParserException
 import com.kotlindiscord.kord.extensions.parsers.InvalidTimeUnitException
@@ -37,6 +38,16 @@ import java.time.LocalDateTime
  * @param longHelp Whether to send the user a long help message with specific information on how to specify durations.
  * @param positiveOnly Whether a positive duration is required - `true` by default.
  */
+@Converter(
+    names = ["j8Duration"],
+    types = [ConverterType.DEFAULTING, ConverterType.OPTIONAL, ConverterType.SINGLE],
+    imports = ["java.time.*"],
+
+    builderFields = [
+        "public var longHelp: Boolean = true",
+        "public var positiveOnly: Boolean = true",
+    ],
+)
 @OptIn(KordPreview::class)
 public class J8DurationConverter(
     public val longHelp: Boolean = true,
@@ -110,87 +121,3 @@ public class J8DurationConverter(
         return true
     }
 }
-
-/**
- * Create a Java 8 Duration converter, for single arguments.
- *
- * @see J8DurationConverter
- */
-public fun Arguments.j8Duration(
-    displayName: String,
-    description: String,
-    requirePositive: Boolean = true,
-    longHelp: Boolean = true,
-    validator: Validator<ChronoContainer> = null,
-): SingleConverter<ChronoContainer> =
-    arg(
-        displayName,
-        description,
-        J8DurationConverter(
-            longHelp = longHelp,
-            positiveOnly = requirePositive,
-            validator = validator
-        )
-    )
-
-/**
- * Create an optional Java 8 Duration converter, for single arguments.
- *
- * @see J8DurationConverter
- */
-public fun Arguments.optionalJ8Duration(
-    displayName: String,
-    description: String,
-    requirePositive: Boolean = true,
-    longHelp: Boolean = true,
-    outputError: Boolean = false,
-    validator: Validator<ChronoContainer?> = null,
-): OptionalConverter<ChronoContainer> =
-    arg(
-        displayName,
-        description,
-        J8DurationConverter(longHelp = longHelp, positiveOnly = requirePositive)
-            .toOptional(outputError = outputError, nestedValidator = validator)
-    )
-
-/**
- * Create a defaulting Java 8 Duration converter, for single arguments.
- *
- * @see J8DurationConverter
- */
-public fun Arguments.defaultingJ8Duration(
-    displayName: String,
-    description: String,
-    requirePositive: Boolean = true,
-    longHelp: Boolean = true,
-    defaultValue: ChronoContainer,
-    validator: Validator<ChronoContainer> = null,
-): DefaultingConverter<ChronoContainer> =
-    arg(
-        displayName,
-        description,
-        J8DurationConverter(longHelp = longHelp, positiveOnly = requirePositive)
-            .toDefaulting(defaultValue, nestedValidator = validator)
-    )
-
-/**
- * Create a Java 8 Duration converter, for lists of arguments.
- *
- * @param required Whether command parsing should fail if no arguments could be converted.
- *
- * @see J8DurationConverter
- */
-public fun Arguments.j8DurationList(
-    displayName: String,
-    description: String,
-    requirePositive: Boolean = true,
-    longHelp: Boolean = true,
-    required: Boolean = true,
-    validator: Validator<List<ChronoContainer>> = null,
-): ListConverter<ChronoContainer> =
-    arg(
-        displayName,
-        description,
-        J8DurationConverter(longHelp = longHelp, positiveOnly = requirePositive)
-            .toList(required, signatureTypeString = "durations", nestedValidator = validator)
-    )

--- a/modules/java-time/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/java/J8DurationConverter.kt
+++ b/modules/java-time/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/java/J8DurationConverter.kt
@@ -145,7 +145,7 @@ public fun Arguments.optionalJ8Duration(
     longHelp: Boolean = true,
     outputError: Boolean = false,
     validator: Validator<ChronoContainer?> = null,
-): OptionalConverter<ChronoContainer?> =
+): OptionalConverter<ChronoContainer> =
     arg(
         displayName,
         description,
@@ -187,10 +187,10 @@ public fun Arguments.j8DurationList(
     longHelp: Boolean = true,
     required: Boolean = true,
     validator: Validator<List<ChronoContainer>> = null,
-): MultiConverter<ChronoContainer> =
+): ListConverter<ChronoContainer> =
     arg(
         displayName,
         description,
         J8DurationConverter(longHelp = longHelp, positiveOnly = requirePositive)
-            .toMulti(required, signatureTypeString = "durations", nestedValidator = validator)
+            .toList(required, signatureTypeString = "durations", nestedValidator = validator)
     )

--- a/modules/java-time/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/TestExtension.kt
+++ b/modules/java-time/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/TestExtension.kt
@@ -9,7 +9,7 @@ package com.kotlindiscord.kord.extensions.test.bot
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.chatCommand
-import com.kotlindiscord.kord.extensions.modules.time.java.coalescedJ8Duration
+import com.kotlindiscord.kord.extensions.modules.time.java.coalescingJ8Duration
 import com.kotlindiscord.kord.extensions.modules.time.java.toHuman
 import com.kotlindiscord.kord.extensions.utils.respond
 import dev.kord.common.annotation.KordPreview
@@ -21,11 +21,10 @@ class TestExtension : Extension() {
     override val name = "test"
 
     class TestArgs : Arguments() {
-        val duration by coalescedJ8Duration(
-            "duration",
-            "Duration argument",
-            shouldThrow = true
-        )
+        val duration by coalescingJ8Duration {
+            name = "duration"
+            description = "Duration argument"
+        }
     }
 
     override suspend fun setup() {

--- a/modules/time4j/build.gradle.kts
+++ b/modules/time4j/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     `kordex-module`
     `published-module`
     `dokka-module`
+    `ksp-module`
 }
 
 dependencies {
@@ -9,7 +10,11 @@ dependencies {
     api(libs.time4j.tzdata)
 
     implementation(libs.kotlin.stdlib)
+
     implementation(project(":kord-extensions"))
+    implementation(project(":annotations"))
+
+    ksp(project(":annotation-processor"))
 
     detektPlugins(libs.detekt)
 

--- a/modules/time4j/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/time4j/T4JDurationCoalescingConverter.kt
+++ b/modules/time4j/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/time4j/T4JDurationCoalescingConverter.kt
@@ -15,11 +15,11 @@ package com.kotlindiscord.kord.extensions.modules.time.time4j
 
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
-import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.CommandContext
 import com.kotlindiscord.kord.extensions.commands.converters.*
-import com.kotlindiscord.kord.extensions.commands.converters.impl.RegexCoalescingConverter
 import com.kotlindiscord.kord.extensions.i18n.EMPTY_VALUE_STRING
+import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
+import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser
 import com.kotlindiscord.kord.extensions.parsers.DurationParserException
 import com.kotlindiscord.kord.extensions.parsers.InvalidTimeUnitException
@@ -42,6 +42,16 @@ import net.time4j.IsoUnit
  * @see coalescedT4jDuration
  * @see parseT4JDuration
  */
+@Converter(
+    names = ["t4JDuration"],
+    types = [ConverterType.COALESCING, ConverterType.DEFAULTING, ConverterType.OPTIONAL],
+    imports = ["net.time4j.*"],
+
+    builderFields = [
+        "public var longHelp: Boolean = true",
+        "public var shouldThrow: Boolean = true"
+    ],
+)
 public class T4JDurationCoalescingConverter(
     public val longHelp: Boolean = true,
     shouldThrow: Boolean = false,
@@ -181,61 +191,3 @@ public class T4JDurationCoalescingConverter(
         return true
     }
 }
-
-/**
- * Create a coalescing Time4J Duration converter.
- *
- * @see RegexCoalescingConverter
- */
-public fun Arguments.coalescedT4jDuration(
-    displayName: String,
-    description: String,
-    longHelp: Boolean = true,
-    shouldThrow: Boolean = false,
-    validator: Validator<Duration<IsoUnit>> = null,
-): CoalescingConverter<Duration<IsoUnit>> =
-    arg(
-        displayName,
-        description,
-        T4JDurationCoalescingConverter(longHelp = longHelp, shouldThrow = shouldThrow, validator = validator)
-    )
-
-/**
- * Create an optional coalescing Time4J Duration converter.
- *
- * @see RegexCoalescingConverter
- */
-public fun Arguments.optionalCoalescedT4jDuration(
-    displayName: String,
-    description: String,
-    longHelp: Boolean = true,
-    outputError: Boolean = false,
-    validator: Validator<Duration<IsoUnit>?> = null,
-): OptionalCoalescingConverter<Duration<IsoUnit>> =
-    arg(
-        displayName,
-        description,
-
-        T4JDurationCoalescingConverter(longHelp = longHelp, shouldThrow = outputError)
-            .toOptional(outputError = outputError, nestedValidator = validator)
-    )
-
-/**
- * Create a defaulting coalescing Time4J Duration converter.
- *
- * @see RegexCoalescingConverter
- */
-public fun Arguments.defaultingCoalescedT4jDuration(
-    displayName: String,
-    description: String,
-    defaultValue: Duration<IsoUnit>,
-    longHelp: Boolean = true,
-    shouldThrow: Boolean = false,
-    validator: Validator<Duration<IsoUnit>> = null,
-): DefaultingCoalescingConverter<Duration<IsoUnit>> =
-    arg(
-        displayName,
-        description,
-        T4JDurationCoalescingConverter(longHelp = longHelp, shouldThrow = shouldThrow)
-            .toDefaulting(defaultValue, nestedValidator = validator)
-    )

--- a/modules/time4j/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/time4j/T4JDurationCoalescingConverter.kt
+++ b/modules/time4j/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/time4j/T4JDurationCoalescingConverter.kt
@@ -211,7 +211,7 @@ public fun Arguments.optionalCoalescedT4jDuration(
     longHelp: Boolean = true,
     outputError: Boolean = false,
     validator: Validator<Duration<IsoUnit>?> = null,
-): OptionalCoalescingConverter<Duration<IsoUnit>?> =
+): OptionalCoalescingConverter<Duration<IsoUnit>> =
     arg(
         displayName,
         description,

--- a/modules/time4j/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/time4j/T4JDurationConverter.kt
+++ b/modules/time4j/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/time4j/T4JDurationConverter.kt
@@ -15,9 +15,10 @@ package com.kotlindiscord.kord.extensions.modules.time.time4j
 
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
-import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.CommandContext
 import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converter
+import com.kotlindiscord.kord.extensions.modules.annotations.converters.ConverterType
 import com.kotlindiscord.kord.extensions.parser.StringParser
 import com.kotlindiscord.kord.extensions.parsers.DurationParserException
 import com.kotlindiscord.kord.extensions.parsers.InvalidTimeUnitException
@@ -40,6 +41,15 @@ import net.time4j.IsoUnit
  * @see parseT4JDuration
  */
 @OptIn(KordPreview::class)
+@Converter(
+    names = ["t4JDuration"],
+    types = [ConverterType.DEFAULTING, ConverterType.OPTIONAL, ConverterType.SINGLE],
+    imports = ["net.time4j.*"],
+
+    builderFields = [
+        "public var longHelp: Boolean = true",
+    ],
+)
 public class T4JDurationConverter(
     public val longHelp: Boolean = true,
     override var validator: Validator<Duration<IsoUnit>> = null
@@ -87,75 +97,3 @@ public class T4JDurationConverter(
         return true
     }
 }
-
-/**
- * Create a Time4J Duration converter, for single arguments.
- *
- * @see T4JDurationConverter
- */
-public fun Arguments.t4jDuration(
-    displayName: String,
-    description: String,
-    longHelp: Boolean = true,
-    validator: Validator<Duration<IsoUnit>> = null,
-): SingleConverter<Duration<IsoUnit>> =
-    arg(displayName, description, T4JDurationConverter(longHelp = longHelp, validator = validator))
-
-/**
- * Create an optional Time4J Duration converter, for single arguments.
- *
- * @see T4JDurationConverter
- */
-public fun Arguments.optionalT4jDuration(
-    displayName: String,
-    description: String,
-    longHelp: Boolean = true,
-    outputError: Boolean = false,
-    validator: Validator<Duration<IsoUnit>?> = null,
-): OptionalConverter<Duration<IsoUnit>> =
-    arg(
-        displayName,
-        description,
-        T4JDurationConverter(longHelp = longHelp)
-            .toOptional(outputError = outputError, nestedValidator = validator)
-    )
-
-/**
- * Create a defaulting Time4J Duration converter, for single arguments.
- *
- * @see T4JDurationConverter
- */
-public fun Arguments.defaultingT4jDuration(
-    displayName: String,
-    description: String,
-    longHelp: Boolean = true,
-    defaultValue: Duration<IsoUnit>,
-    validator: Validator<Duration<IsoUnit>> = null,
-): DefaultingConverter<Duration<IsoUnit>> =
-    arg(
-        displayName,
-        description,
-        T4JDurationConverter(longHelp = longHelp)
-            .toDefaulting(defaultValue, nestedValidator = validator)
-    )
-
-/**
- * Create a Time4J Duration converter, for lists of arguments.
- *
- * @param required Whether command parsing should fail if no arguments could be converted.
- *
- * @see T4JDurationConverter
- */
-public fun Arguments.t4jDurationList(
-    displayName: String,
-    description: String,
-    longHelp: Boolean = true,
-    required: Boolean = true,
-    validator: Validator<List<Duration<IsoUnit>>> = null,
-): ListConverter<Duration<IsoUnit>> =
-    arg(
-        displayName,
-        description,
-        T4JDurationConverter(longHelp = longHelp)
-            .toList(required, signatureTypeString = "durations", nestedValidator = validator)
-    )

--- a/modules/time4j/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/time4j/T4JDurationConverter.kt
+++ b/modules/time4j/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/time4j/T4JDurationConverter.kt
@@ -112,7 +112,7 @@ public fun Arguments.optionalT4jDuration(
     longHelp: Boolean = true,
     outputError: Boolean = false,
     validator: Validator<Duration<IsoUnit>?> = null,
-): OptionalConverter<Duration<IsoUnit>?> =
+): OptionalConverter<Duration<IsoUnit>> =
     arg(
         displayName,
         description,
@@ -152,10 +152,10 @@ public fun Arguments.t4jDurationList(
     longHelp: Boolean = true,
     required: Boolean = true,
     validator: Validator<List<Duration<IsoUnit>>> = null,
-): MultiConverter<Duration<IsoUnit>> =
+): ListConverter<Duration<IsoUnit>> =
     arg(
         displayName,
         description,
         T4JDurationConverter(longHelp = longHelp)
-            .toMulti(required, signatureTypeString = "durations", nestedValidator = validator)
+            .toList(required, signatureTypeString = "durations", nestedValidator = validator)
     )

--- a/modules/time4j/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/TestExtension.kt
+++ b/modules/time4j/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/TestExtension.kt
@@ -9,7 +9,7 @@ package com.kotlindiscord.kord.extensions.test.bot
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.chatCommand
-import com.kotlindiscord.kord.extensions.modules.time.time4j.coalescedT4jDuration
+import com.kotlindiscord.kord.extensions.modules.time.time4j.coalescingT4JDuration
 import com.kotlindiscord.kord.extensions.modules.time.time4j.toHuman
 import com.kotlindiscord.kord.extensions.utils.respond
 import dev.kord.common.annotation.KordPreview
@@ -21,11 +21,10 @@ class TestExtension : Extension() {
     override val name = "test"
 
     class TestArgs : Arguments() {
-        val duration by coalescedT4jDuration(
-            "duration",
-            "Duration argument",
-            shouldThrow = true
-        )
+        val duration by coalescingT4JDuration {
+            name = "duration"
+            description = "Duration argument"
+        }
     }
 
     override suspend fun setup() {

--- a/modules/unsafe/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/unsafe/converters/UnionConverter.kt
+++ b/modules/unsafe/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/unsafe/converters/UnionConverter.kt
@@ -119,7 +119,7 @@ public class UnionConverter(
                     if (shouldThrow) throw t
                 }
 
-                is MultiConverter<*> -> try {
+                is ListConverter<*> -> try {
                     val result: Int = converter.parse(parser, context, named)
 
                     if (result > 0) {
@@ -229,7 +229,7 @@ public class UnionConverter(
                     if (shouldThrow) throw t
                 }
 
-                is MultiConverter<*> -> throw DiscordRelayedException(
+                is ListConverter<*> -> throw DiscordRelayedException(
                     context.translate(
                         "converters.union.error.unknownConverterType",
                         replacements = arrayOf(converter)
@@ -339,7 +339,7 @@ public fun Arguments.optionalUnion(
     vararg converters: GenericConverter,
     bundle: String? = null,
     validator: Validator<Any?> = null
-): OptionalCoalescingConverter<Any?> {
+): OptionalCoalescingConverter<Any> {
     val converter: UnionConverter = UnionConverter(converters.toList(), typeName, shouldThrow, bundle)
 
     converter.validateUnion()
@@ -350,7 +350,7 @@ public fun Arguments.optionalUnion(
         }
     }
 
-    val optionalConverter: OptionalCoalescingConverter<Any?> = converter.toOptional(nestedValidator = validator)
+    val optionalConverter: OptionalCoalescingConverter<Any> = converter.toOptional(nestedValidator = validator)
 
     arg(displayName, description, optionalConverter)
 


### PR DESCRIPTION
This is the first version of KordEx with a new converter annotation system, and DSL-style converter settings. The changes are _not_ documented yet, but they will be!

That's also why this is a bump.