### PR TITLE
Add support for slash command localizations

### DIFF
--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/builders/ExtensibleBotBuilder.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/builders/ExtensibleBotBuilder.kt
@@ -66,6 +66,7 @@ import java.nio.file.Path
 import java.util.*
 import kotlin.io.path.Path
 import kotlin.io.path.div
+import dev.kord.common.Locale as KLocale
 
 internal typealias LocaleResolver = suspend (
     guild: GuildBehavior?,
@@ -963,6 +964,11 @@ public open class ExtensibleBotBuilder {
         public var defaultLocale: Locale = SupportedLocales.ENGLISH
 
         /**
+         * List of [locales][KLocale] which are used for application command names (without [defaultLocale]).
+         */
+        public var applicationCommandLocales: MutableList<KLocale> = mutableListOf()
+
+        /**
          * Callables used to resolve a Locale object for the given guild, channel and user.
          *
          * Resolves to [defaultLocale] by default.
@@ -980,6 +986,15 @@ public open class ExtensibleBotBuilder {
         /** Register a locale resolver, returning the required [Locale] object or `null`. **/
         public fun localeResolver(body: LocaleResolver) {
             localeResolvers.add(body)
+        }
+
+        /**
+         * Registers [locale] as an application command language.
+         *
+         * **Do not register [defaultLocale]**
+         */
+        public fun applicationCommandLocale(vararg locale: KLocale) {
+            applicationCommandLocales.addAll(locale.toList())
         }
 
         /**

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/ApplicationCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/ApplicationCommand.kt
@@ -7,6 +7,8 @@
 package com.kotlindiscord.kord.extensions.commands.application
 
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
+import com.kotlindiscord.kord.extensions.ExtensibleBot
+import com.kotlindiscord.kord.extensions.builders.ExtensibleBotBuilder
 import com.kotlindiscord.kord.extensions.checks.types.Check
 import com.kotlindiscord.kord.extensions.checks.types.CheckContext
 import com.kotlindiscord.kord.extensions.commands.Command
@@ -20,6 +22,9 @@ import dev.kord.core.behavior.GuildBehavior
 import dev.kord.core.behavior.RoleBehavior
 import dev.kord.core.behavior.UserBehavior
 import dev.kord.core.event.interaction.InteractionCreateEvent
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import dev.kord.common.Locale as KLocale
 import java.util.*
 
 /**
@@ -29,7 +34,22 @@ import java.util.*
  */
 public abstract class ApplicationCommand<E : InteractionCreateEvent>(
     extension: Extension
-) : Command(extension) {
+) : Command(extension), KoinComponent {
+    /** Translations provider, for retrieving translations. **/
+    public val translationsProvider: TranslationsProvider by inject()
+    protected val bot: ExtensibleBot by inject()
+
+    /** Quick access to the command registry. **/
+    public val registry: ApplicationCommandRegistry by inject()
+
+    /** Bot settings object. **/
+    public val settings: ExtensibleBotBuilder by inject()
+
+    /** Kord instance, backing the ExtensibleBot. **/
+    public val kord: Kord by inject()
+
+    /** Sentry adapter, for easy access to Sentry functions. **/
+    public val sentry: SentryAdapter by inject()
 
     /** Discord-side command type, for matching up. **/
     public abstract val type: ApplicationCommandType
@@ -70,17 +90,32 @@ public abstract class ApplicationCommand<E : InteractionCreateEvent>(
      */
     public open val disallowedUsers: MutableSet<Snowflake> = mutableSetOf()
 
-    /** Return this command's name translated for the given locale, cached as required. **/
-    public open fun getTranslatedName(locale: Locale): String {
-        if (!nameTranslationCache.containsKey(locale)) {
-            nameTranslationCache[locale] = translationsProvider.translate(
-                this.name,
+    /** Permissions required to be able to run this command. **/
+    public open val requiredPerms: MutableSet<Permission> = mutableSetOf()
+
+    /**
+     * A [Localized] version of [name].
+     */
+    public val localizedName: Localized<String> by lazy { localize(name) }
+
+    /**
+     * Localizes a property by its [key] for this command.
+     */
+    public fun localize(key: String): Localized<String> {
+        val default = translationsProvider.translate(
+            key,
+            this.resolvedBundle,
+            translationsProvider.defaultLocale
+        )
+        val translations = bot.settings.i18nBuilder.applicationCommandLocales.associateWith { locale ->
+            translationsProvider.translate(
+                key,
                 this.resolvedBundle,
-                locale
+                locale.asJavaLocale()
             )
         }
 
-        return nameTranslationCache[locale]!!
+        return Localized(default, translations.toMutableMap())
     }
 
     /** If your bot requires permissions to be able to execute the command, add them using this function. **/
@@ -226,3 +261,12 @@ public abstract class ApplicationCommand<E : InteractionCreateEvent>(
     /** Override this to implement the calling logic for your subclass. **/
     public abstract suspend fun call(event: E)
 }
+
+/**
+ * Representation of a localized object.
+ *
+ * @property default the default translations
+ * @property translations a map containing all localizations
+ * @param T the type of the object
+ */
+public data class Localized<T>(val default: T, val translations: MutableMap<KLocale, String>)

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/ApplicationCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/ApplicationCommand.kt
@@ -8,7 +8,6 @@ package com.kotlindiscord.kord.extensions.commands.application
 
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.ExtensibleBot
-import com.kotlindiscord.kord.extensions.builders.ExtensibleBotBuilder
 import com.kotlindiscord.kord.extensions.checks.types.Check
 import com.kotlindiscord.kord.extensions.checks.types.CheckContext
 import com.kotlindiscord.kord.extensions.commands.Command
@@ -25,7 +24,6 @@ import dev.kord.core.event.interaction.InteractionCreateEvent
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import dev.kord.common.Locale as KLocale
-import java.util.*
 
 /**
  * Abstract class representing an application command - extend this for actual implementations.
@@ -36,20 +34,10 @@ public abstract class ApplicationCommand<E : InteractionCreateEvent>(
     extension: Extension
 ) : Command(extension), KoinComponent {
     /** Translations provider, for retrieving translations. **/
-    public val translationsProvider: TranslationsProvider by inject()
     protected val bot: ExtensibleBot by inject()
 
     /** Quick access to the command registry. **/
     public val registry: ApplicationCommandRegistry by inject()
-
-    /** Bot settings object. **/
-    public val settings: ExtensibleBotBuilder by inject()
-
-    /** Kord instance, backing the ExtensibleBot. **/
-    public val kord: Kord by inject()
-
-    /** Sentry adapter, for easy access to Sentry functions. **/
-    public val sentry: SentryAdapter by inject()
 
     /** Discord-side command type, for matching up. **/
     public abstract val type: ApplicationCommandType
@@ -91,7 +79,7 @@ public abstract class ApplicationCommand<E : InteractionCreateEvent>(
     public open val disallowedUsers: MutableSet<Snowflake> = mutableSetOf()
 
     /** Permissions required to be able to run this command. **/
-    public open val requiredPerms: MutableSet<Permission> = mutableSetOf()
+    public override val requiredPerms: MutableSet<Permission> = mutableSetOf()
 
     /**
      * A [Localized] version of [name].

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/ApplicationCommandRegistry.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/ApplicationCommandRegistry.kt
@@ -28,6 +28,7 @@ import dev.kord.common.annotation.KordUnsafe
 import dev.kord.common.entity.ApplicationCommandType
 import dev.kord.common.entity.Choice
 import dev.kord.common.entity.Snowflake
+import dev.kord.common.entity.optional.Optional
 import dev.kord.core.Kord
 import dev.kord.core.behavior.createChatInputCommand
 import dev.kord.core.behavior.createMessageCommand
@@ -563,9 +564,9 @@ public abstract class ApplicationCommandRegistry : KoinComponent {
             val (name, nameLocalizations) = command.localize(it.name)
 
             when (it) {
-                is Choice.IntChoice -> Choice.IntChoice(name, nameLocalizations, it.value)
-                is Choice.NumberChoice -> Choice.NumberChoice(name, nameLocalizations, it.value)
-                is Choice.StringChoice -> Choice.StringChoice(name, nameLocalizations, it.value)
+                is Choice.IntChoice -> Choice.IntChoice(name, Optional(nameLocalizations), it.value)
+                is Choice.NumberChoice -> Choice.NumberChoice(name, Optional(nameLocalizations), it.value)
+                is Choice.StringChoice -> Choice.StringChoice(name, Optional(nameLocalizations), it.value)
             }
         }.toMutableList()
     }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/SlashCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/SlashCommand.kt
@@ -66,10 +66,12 @@ public abstract class SlashCommand<C : SlashCommandContext<*, A>, A : Arguments>
     /** List of subcommands, if any. **/
     public open val subCommands: MutableList<SlashCommand<*, *>> = mutableListOf()
 
-    override val type: ApplicationCommandType = ApplicationCommandType.ChatInput
+    /**
+     * A [Localized] version of [description].
+     */
+    public val localizedDescription: Localized<String> by lazy { localize(description) }
 
-    /** Translation cache, so we don't have to look up translations every time. **/
-    public open val descriptionTranslationCache: MutableMap<Locale, String> = mutableMapOf()
+    override val type: ApplicationCommandType = ApplicationCommandType.ChatInput
 
     override var guildId: Snowflake? = if (parentCommand == null && parentGroup == null) {
         settings.applicationCommandsBuilder.defaultGuild
@@ -105,35 +107,6 @@ public abstract class SlashCommand<C : SlashCommandContext<*, A>, A : Arguments>
                     "instead."
             )
         }
-    }
-
-    public override fun getTranslatedName(locale: Locale): String {
-        // Only slash commands need this to be lower-cased.
-
-        if (!nameTranslationCache.containsKey(locale)) {
-            nameTranslationCache[locale] = translationsProvider.translate(
-                this.name,
-                this.resolvedBundle,
-                locale
-            ).lowercase()
-        }
-
-        return nameTranslationCache[locale]!!
-    }
-
-    /** Return this command's description translated for the given locale, cached as required. **/
-    public fun getTranslatedDescription(locale: Locale): String {
-        // Only slash commands need this to be lower-cased.
-
-        if (!descriptionTranslationCache.containsKey(locale)) {
-            descriptionTranslationCache[locale] = translationsProvider.translate(
-                this.description,
-                this.resolvedBundle,
-                locale
-            )
-        }
-
-        return descriptionTranslationCache[locale]!!
     }
 
     /** Call this to supply a command [body], to be called when the command is executed. **/

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/SlashCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/SlashCommand.kt
@@ -10,7 +10,7 @@ import com.kotlindiscord.kord.extensions.InvalidCommandException
 import com.kotlindiscord.kord.extensions.checks.types.CheckContext
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.application.ApplicationCommand
-import com.kotlindiscord.kord.extensions.commands.application.ApplicationCommandRegistry
+import com.kotlindiscord.kord.extensions.commands.application.Localized
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.sentry.BreadcrumbType
 import com.kotlindiscord.kord.extensions.sentry.tag
@@ -28,8 +28,6 @@ import dev.kord.core.event.interaction.AutoCompleteInteractionCreateEvent
 import dev.kord.core.event.interaction.ChatInputCommandInteractionCreateEvent
 import mu.KLogger
 import mu.KotlinLogging
-import org.koin.core.component.inject
-import java.util.*
 
 /**
  * Slash command, executed directly in the chat input.
@@ -47,9 +45,6 @@ public abstract class SlashCommand<C : SlashCommandContext<*, A>, A : Arguments>
 ) : ApplicationCommand<ChatInputCommandInteractionCreateEvent>(extension) {
     /** @suppress This is only meant for use by code that extends the command system. **/
     public val kxLogger: KLogger = KotlinLogging.logger {}
-
-    /** Application command registry. **/
-    public val registry: ApplicationCommandRegistry by inject()
 
     /** Command description, as displayed on Discord. **/
     public open lateinit var description: String


### PR DESCRIPTION
<!--
Hello, and thanks for submitting a pull request! To help us address this PR
quickly, please take the time to fill out this template to the best of
your ability, and please provide as much information as possible!

When you're done, feel free to remove these comments if you like.

Additionally, please remember that PRs are not the place to disclose
a security issue. Instead, please contact a member of our admin team directly
on Discord, or send a private message to the ModMail bot there.

This doesn't mean that you can't contribute to security fixes - we just
require that they be contributed as part of a proper security advisory, so
that they can be worked on without risking wider exposure of the vulnerability
before it is fixed.
-->

# Relevant Issues
kordlib/kord#570

# Description

Discord now added translations for the slash command UI, this PR now acceppts the existing translation strings in name and description fields

