### PR TITLE
Fix inconsistent/extension plugin loading

### DIFF
--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/plugins/KordExPlugin.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/plugins/KordExPlugin.kt
@@ -9,6 +9,7 @@ package com.kotlindiscord.kord.extensions.plugins
 import com.kotlindiscord.kord.extensions.ExtensibleBot
 import dev.kord.core.Kord
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.pf4j.Plugin
@@ -78,15 +79,15 @@ public abstract class KordExPlugin(wrapper: PluginWrapper) : Plugin(wrapper), Ko
         }
     }
 
-    override fun start() {
-        kord.launch { asyncStart() }
+    override fun start(): Unit = runBlocking {
+        kord.launch { asyncStart() }.join()
     }
 
-    override fun stop() {
-        kord.launch { asyncStop() }
+    override fun stop(): Unit = runBlocking {
+        kord.launch { asyncStop() }.join()
     }
 
-    override fun delete() {
-        kord.launch { asyncDelete() }
+    override fun delete(): Unit = runBlocking {
+        kord.launch { asyncDelete() }.join()
     }
 }

--- a/kord-extensions/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/Bot.kt
+++ b/kord-extensions/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/Bot.kt
@@ -46,8 +46,6 @@ suspend fun main() {
         }
 
         extensions {
-            add(::TestExtension)
-
             help {
                 paginatorTimeout = 30
             }

--- a/kord-extensions/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/TestExtension.kt
+++ b/kord-extensions/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/TestExtension.kt
@@ -326,7 +326,7 @@ class TestExtension : Extension() {
             name = "pages"
             description = "Pages!"
 
-            guild(787452339908116521)
+            guild(TEST_SERVER_ID)
 
             action {
                 editingPaginator("short") {
@@ -372,7 +372,7 @@ class TestExtension : Extension() {
             name = "buttons"
             description = "Buttons!"
 
-            guild(787452339908116521) // Our test server
+            guild(TEST_SERVER_ID) // Our test server
 
             action {
                 respond {
@@ -415,7 +415,7 @@ class TestExtension : Extension() {
             name = "test-noack"
             description = "Don't auto-ack this one"
 
-            guild(787452339908116521) // Our test server
+            guild(TEST_SERVER_ID) // Our test server
 
             initialResponse {
                 embed {
@@ -432,7 +432,7 @@ class TestExtension : Extension() {
             name = "choice"
             description = "Choice-based"
 
-            guild(787452339908116521) // Our test server
+            guild(TEST_SERVER_ID) // Our test server
 
             action {
                 respond {
@@ -445,7 +445,7 @@ class TestExtension : Extension() {
             name = "group"
             description = "Test command, please ignore"
 
-            guild(787452339908116521) // Our test server
+            guild(TEST_SERVER_ID) // Our test server
 
             group("one") {
                 description = "Group one"
@@ -504,7 +504,7 @@ class TestExtension : Extension() {
             name = "guild-embed"
             description = "Test command, please ignore"
 
-            guild(787452339908116521) // Our test server
+            guild(TEST_SERVER_ID) // Our test server
 
             group("first") {
                 description = "First group."
@@ -552,7 +552,7 @@ class TestExtension : Extension() {
 
                 "Now with some newlines in the description!"
 
-            guild(787452339908116521) // Our test server
+            guild(TEST_SERVER_ID) // Our test server
 
             action {
                 respond {

--- a/kord-extensions/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/TestPlugin.kt
+++ b/kord-extensions/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/TestPlugin.kt
@@ -16,6 +16,6 @@ import org.pf4j.PluginWrapper
 )
 class TestPlugin(wrapper: PluginWrapper) : KordExPlugin(wrapper) {
     override suspend fun setup() {
-//        extension(::TestExtension)
+        extension(::TestExtension)
     }
 }


### PR DESCRIPTION
Coroutines were started in Plugin start/stop/delete but weren't joined which lead to inconsistent loading of plugins and extensions.
I also replaced hard coded test server ids in TestExtension with the TEST_SERVER_ID constant.