### PR TITLE
Cleaning: Abstractions, old docs or docs mistake fixes

### DIFF
--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/builders/ExtensibleBotBuilder.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/builders/ExtensibleBotBuilder.kt
@@ -867,7 +867,7 @@ public open class ExtensibleBotBuilder {
                     it.invoke()
                 } catch (t: Throwable) {
                     logger.error(t) {
-                        "Failed to run beforeKoinSetup hook $it"
+                        "Failed to run afterKoinSetup hook $it"
                     }
                 }
             }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/_Logging.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/_Logging.kt
@@ -34,7 +34,7 @@ public inline fun KLogger.nullGuild(event: Event): Unit =
 public inline fun KLogger.nullMember(event: Event): Unit =
     debug { "Member for event $event is null. This type of event may not be supported." }
 
-/** Convenience wrapper for a "member for event is null" log message. **/
+/** Convenience wrapper for a "message for event is null" log message. **/
 public inline fun KLogger.nullMessage(event: Event): Unit =
     debug { "Message for event $event is null. This type of event may not be supported." }
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/Command.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/Command.kt
@@ -12,7 +12,6 @@ import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.InvalidCommandException
 import com.kotlindiscord.kord.extensions.annotations.ExtensionDSL
 import com.kotlindiscord.kord.extensions.builders.ExtensibleBotBuilder
-import com.kotlindiscord.kord.extensions.commands.chat.ChatCommandRegistry
 import com.kotlindiscord.kord.extensions.commands.events.CommandEvent
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.i18n.TranslationsProvider
@@ -64,9 +63,6 @@ public abstract class Command(public val extension: Extension) : Lockable, KoinC
 
     /** Bot settings object. **/
     public val settings: ExtensibleBotBuilder by inject()
-
-    /** Message command registry. **/
-    public val registry: ChatCommandRegistry by inject()
 
     /** Sentry adapter, for easy access to Sentry functions. **/
     public val sentry: SentryAdapter by inject()

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/Command.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/Command.kt
@@ -129,5 +129,4 @@ public abstract class Command(public val extension: Extension) : Lockable, KoinC
             }
         }
     }
-
 }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/Command.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/Command.kt
@@ -8,14 +8,27 @@
 
 package com.kotlindiscord.kord.extensions.commands
 
+import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.InvalidCommandException
 import com.kotlindiscord.kord.extensions.annotations.ExtensionDSL
+import com.kotlindiscord.kord.extensions.builders.ExtensibleBotBuilder
+import com.kotlindiscord.kord.extensions.commands.chat.ChatCommandRegistry
 import com.kotlindiscord.kord.extensions.commands.events.CommandEvent
 import com.kotlindiscord.kord.extensions.extensions.Extension
+import com.kotlindiscord.kord.extensions.i18n.TranslationsProvider
+import com.kotlindiscord.kord.extensions.sentry.SentryAdapter
 import com.kotlindiscord.kord.extensions.types.Lockable
+import com.kotlindiscord.kord.extensions.utils.permissionsForMember
+import com.kotlindiscord.kord.extensions.utils.translate
+import dev.kord.common.entity.Permission
+import dev.kord.core.Kord
+import dev.kord.core.entity.channel.GuildChannel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import java.util.*
 
 /**
  * Abstract base class representing the few things that command objects can have in common.
@@ -25,7 +38,7 @@ import kotlinx.coroutines.sync.Mutex
  * @property extension The extension object this command belongs to.
  */
 @ExtensionDSL
-public abstract class Command(public val extension: Extension) : Lockable {
+public abstract class Command(public val extension: Extension) : Lockable, KoinComponent {
     /**
      * The name of this command, for invocation and help commands.
      */
@@ -35,6 +48,27 @@ public abstract class Command(public val extension: Extension) : Lockable {
     public override var locking: Boolean = false
 
     override var mutex: Mutex? = null
+
+    /** Translations provider, for retrieving translations. **/
+    public val translationsProvider: TranslationsProvider by inject()
+
+    /** Bot settings object. **/
+    public val settings: ExtensibleBotBuilder by inject()
+
+    /** Message command registry. **/
+    public val registry: ChatCommandRegistry by inject()
+
+    /** Sentry adapter, for easy access to Sentry functions. **/
+    public val sentry: SentryAdapter by inject()
+
+    /** Kord instance, backing the ExtensibleBot. **/
+    public val kord: Kord by inject()
+
+    /** Permissions required to be able to run this command. **/
+    public open val requiredPerms: MutableSet<Permission> = mutableSetOf()
+
+    /** Translation cache, so we don't have to look up translations every time. **/
+    public open val nameTranslationCache: MutableMap<Locale, String> = mutableMapOf()
 
     /**
      * An internal function used to ensure that all of a command's required arguments are present and correct.
@@ -57,4 +91,33 @@ public abstract class Command(public val extension: Extension) : Lockable {
         event.launch {
             extension.bot.send(event)
         }
+
+    /** Checks whether the bot has the specified required permissions, throwing if it doesn't. **/
+    @Throws(DiscordRelayedException::class)
+    public open suspend fun checkBotPerms(context: CommandContext) {
+        if (requiredPerms.isEmpty()) {
+            return  // Nothing to check, don't try to hit the cache
+        }
+
+        if (context.getGuild() != null) {
+            val perms = (context.getChannel().asChannel() as GuildChannel)
+                .permissionsForMember(kord.selfId)
+
+            val missingPerms = requiredPerms.filter { !perms.contains(it) }
+
+            if (missingPerms.isNotEmpty()) {
+                throw DiscordRelayedException(
+                    context.translate(
+                        "commands.error.missingBotPermissions",
+                        null,
+
+                        replacements = arrayOf(
+                            missingPerms.map { it.translate(context.getLocale()) }.joinToString(", ")
+                        )
+                    )
+                )
+            }
+        }
+    }
+
 }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/CommandContext.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/CommandContext.kt
@@ -49,8 +49,8 @@ public abstract class CommandContext(
     /** Called before processing, used to populate any extra variables from event data. **/
     public abstract suspend fun populate()
 
-    /** Extract channel information from event data, if that context is available. **/
-    public abstract suspend fun getChannel(): ChannelBehavior?
+    /** Extract channel information from event data. **/
+    public abstract suspend fun getChannel(): ChannelBehavior
 
     /** Extract guild information from event data, if that context is available. **/
     public abstract suspend fun getGuild(): GuildBehavior?

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/ApplicationCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/ApplicationCommand.kt
@@ -7,25 +7,19 @@
 package com.kotlindiscord.kord.extensions.commands.application
 
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
-import com.kotlindiscord.kord.extensions.builders.ExtensibleBotBuilder
 import com.kotlindiscord.kord.extensions.checks.types.Check
 import com.kotlindiscord.kord.extensions.checks.types.CheckContext
 import com.kotlindiscord.kord.extensions.commands.Command
 import com.kotlindiscord.kord.extensions.extensions.Extension
-import com.kotlindiscord.kord.extensions.i18n.TranslationsProvider
-import com.kotlindiscord.kord.extensions.sentry.SentryAdapter
 import com.kotlindiscord.kord.extensions.utils.any
 import com.kotlindiscord.kord.extensions.utils.getLocale
 import dev.kord.common.entity.ApplicationCommandType
 import dev.kord.common.entity.Permission
 import dev.kord.common.entity.Snowflake
-import dev.kord.core.Kord
 import dev.kord.core.behavior.GuildBehavior
 import dev.kord.core.behavior.RoleBehavior
 import dev.kord.core.behavior.UserBehavior
 import dev.kord.core.event.interaction.InteractionCreateEvent
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 import java.util.*
 
 /**
@@ -35,21 +29,7 @@ import java.util.*
  */
 public abstract class ApplicationCommand<E : InteractionCreateEvent>(
     extension: Extension
-) : Command(extension), KoinComponent {
-    /** Translations provider, for retrieving translations. **/
-    public val translationsProvider: TranslationsProvider by inject()
-
-    /** Quick access to the command registry. **/
-    public val registry: ApplicationCommandRegistry by inject()
-
-    /** Bot settings object. **/
-    public val settings: ExtensibleBotBuilder by inject()
-
-    /** Kord instance, backing the ExtensibleBot. **/
-    public val kord: Kord by inject()
-
-    /** Sentry adapter, for easy access to Sentry functions. **/
-    public val sentry: SentryAdapter by inject()
+) : Command(extension) {
 
     /** Discord-side command type, for matching up. **/
     public abstract val type: ApplicationCommandType
@@ -89,15 +69,6 @@ public abstract class ApplicationCommand<E : InteractionCreateEvent>(
      * List of disallowed invoker IDs. Allows take priority over disallows.
      */
     public open val disallowedUsers: MutableSet<Snowflake> = mutableSetOf()
-
-    /** Permissions required to be able to run this command. **/
-    public open val requiredPerms: MutableSet<Permission> = mutableSetOf()
-
-    /** Translation cache, so we don't have to look up translations every time. **/
-    public open val nameTranslationCache: MutableMap<Locale, String> = mutableMapOf()
-
-    /** Translation cache, so we don't have to look up translations every time. **/
-    public open val descriptionTranslationCache: MutableMap<Locale, String> = mutableMapOf()
 
     /** Return this command's name translated for the given locale, cached as required. **/
     public open fun getTranslatedName(locale: Locale): String {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/message/MessageCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/message/MessageCommand.kt
@@ -6,7 +6,6 @@
 
 package com.kotlindiscord.kord.extensions.commands.application.message
 
-import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.InvalidCommandException
 import com.kotlindiscord.kord.extensions.checks.types.CheckContext
 import com.kotlindiscord.kord.extensions.commands.application.ApplicationCommand
@@ -16,11 +15,8 @@ import com.kotlindiscord.kord.extensions.sentry.tag
 import com.kotlindiscord.kord.extensions.sentry.user
 import com.kotlindiscord.kord.extensions.types.FailureReason
 import com.kotlindiscord.kord.extensions.utils.getLocale
-import com.kotlindiscord.kord.extensions.utils.permissionsForMember
-import com.kotlindiscord.kord.extensions.utils.translate
 import dev.kord.common.entity.ApplicationCommandType
 import dev.kord.core.entity.channel.DmChannel
-import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.entity.channel.GuildMessageChannel
 import dev.kord.core.event.interaction.MessageCommandInteractionCreateEvent
 import mu.KLogger
@@ -55,34 +51,6 @@ public abstract class MessageCommand<C : MessageCommandContext<*>>(
 
     /** Override this to implement a way to respond to the user, regardless of whatever happens. **/
     public abstract suspend fun respondText(context: C, message: String, failureType: FailureReason<*>)
-
-    /** Checks whether the bot has the specified required permissions, throwing if it doesn't. **/
-    @Throws(DiscordRelayedException::class)
-    public open suspend fun checkBotPerms(context: C) {
-        if (requiredPerms.isEmpty()) {
-            return  // Nothing to check, don't try to hit the cache
-        }
-
-        if (context.guild != null) {
-            val perms = (context.channel.asChannel() as GuildChannel)
-                .permissionsForMember(kord.selfId)
-
-            val missingPerms = requiredPerms.filter { !perms.contains(it) }
-
-            if (missingPerms.isNotEmpty()) {
-                throw DiscordRelayedException(
-                    context.translate(
-                        "commands.error.missingBotPermissions",
-                        null,
-
-                        replacements = arrayOf(
-                            missingPerms.map { it.translate(context.getLocale()) }.joinToString(", ")
-                        )
-                    )
-                )
-            }
-        }
-    }
 
     /** If enabled, adds the initial Sentry breadcrumb to the given context. **/
     public open suspend fun firstSentryBreadcrumb(context: C) {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/SlashCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/SlashCommand.kt
@@ -10,6 +10,7 @@ import com.kotlindiscord.kord.extensions.InvalidCommandException
 import com.kotlindiscord.kord.extensions.checks.types.CheckContext
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.application.ApplicationCommand
+import com.kotlindiscord.kord.extensions.commands.application.ApplicationCommandRegistry
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.sentry.BreadcrumbType
 import com.kotlindiscord.kord.extensions.sentry.tag
@@ -27,6 +28,7 @@ import dev.kord.core.event.interaction.AutoCompleteInteractionCreateEvent
 import dev.kord.core.event.interaction.ChatInputCommandInteractionCreateEvent
 import mu.KLogger
 import mu.KotlinLogging
+import org.koin.core.component.inject
 import java.util.*
 
 /**
@@ -45,6 +47,9 @@ public abstract class SlashCommand<C : SlashCommandContext<*, A>, A : Arguments>
 ) : ApplicationCommand<ChatInputCommandInteractionCreateEvent>(extension) {
     /** @suppress This is only meant for use by code that extends the command system. **/
     public val kxLogger: KLogger = KotlinLogging.logger {}
+
+    /** Application command registry. **/
+    public val registry: ApplicationCommandRegistry by inject()
 
     /** Command description, as displayed on Discord. **/
     public open lateinit var description: String

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/user/UserCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/user/UserCommand.kt
@@ -6,7 +6,6 @@
 
 package com.kotlindiscord.kord.extensions.commands.application.user
 
-import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.InvalidCommandException
 import com.kotlindiscord.kord.extensions.checks.types.CheckContext
 import com.kotlindiscord.kord.extensions.commands.application.ApplicationCommand
@@ -16,11 +15,8 @@ import com.kotlindiscord.kord.extensions.sentry.tag
 import com.kotlindiscord.kord.extensions.sentry.user
 import com.kotlindiscord.kord.extensions.types.FailureReason
 import com.kotlindiscord.kord.extensions.utils.getLocale
-import com.kotlindiscord.kord.extensions.utils.permissionsForMember
-import com.kotlindiscord.kord.extensions.utils.translate
 import dev.kord.common.entity.ApplicationCommandType
 import dev.kord.core.entity.channel.DmChannel
-import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.entity.channel.GuildMessageChannel
 import dev.kord.core.event.interaction.UserCommandInteractionCreateEvent
 import mu.KLogger
@@ -55,34 +51,6 @@ public abstract class UserCommand<C : UserCommandContext<*>>(
 
     /** Override this to implement a way to respond to the user, regardless of whatever happens. **/
     public abstract suspend fun respondText(context: C, message: String, failureType: FailureReason<*>)
-
-    /** Checks whether the bot has the specified required permissions, throwing if it doesn't. **/
-    @Throws(DiscordRelayedException::class)
-    public open suspend fun checkBotPerms(context: C) {
-        if (requiredPerms.isEmpty()) {
-            return  // Nothing to check, don't try to hit the cache
-        }
-
-        if (context.guild != null) {
-            val perms = (context.channel.asChannel() as GuildChannel)
-                .permissionsForMember(kord.selfId)
-
-            val missingPerms = requiredPerms.filter { !perms.contains(it) }
-
-            if (missingPerms.isNotEmpty()) {
-                throw DiscordRelayedException(
-                    context.translate(
-                        "commands.error.missingBotPermissions",
-                        null,
-
-                        replacements = arrayOf(
-                            missingPerms.map { it.translate(context.getLocale()) }.joinToString(", ")
-                        )
-                    )
-                )
-            }
-        }
-    }
 
     /** If enabled, adds the initial Sentry breadcrumb to the given context. **/
     public open suspend fun firstSentryBreadcrumb(context: C) {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/chat/ChatCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/chat/ChatCommand.kt
@@ -31,6 +31,7 @@ import dev.kord.core.entity.channel.DmChannel
 import dev.kord.core.entity.channel.GuildMessageChannel
 import dev.kord.core.event.message.MessageCreateEvent
 import mu.KotlinLogging
+import org.koin.core.component.inject
 import java.util.*
 
 private val logger = KotlinLogging.logger {}
@@ -121,6 +122,9 @@ public open class ChatCommand<T : Arguments>(
 
     /** Locale-based cache of generated signature strings. **/
     public open var signatureCache: MutableMap<Locale, String> = mutableMapOf()
+
+    /** Chat command registry. **/
+    public val registry: ChatCommandRegistry by inject()
 
     /**
      * Retrieve the command signature for a locale, which specifies how the command's arguments should be structured.

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/chat/ChatCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/chat/ChatCommand.kt
@@ -12,7 +12,6 @@ import com.kotlindiscord.kord.extensions.ArgumentParsingException
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.InvalidCommandException
 import com.kotlindiscord.kord.extensions.annotations.ExtensionDSL
-import com.kotlindiscord.kord.extensions.builders.ExtensibleBotBuilder
 import com.kotlindiscord.kord.extensions.checks.types.Check
 import com.kotlindiscord.kord.extensions.checks.types.CheckContext
 import com.kotlindiscord.kord.extensions.commands.Arguments
@@ -20,26 +19,18 @@ import com.kotlindiscord.kord.extensions.commands.Command
 import com.kotlindiscord.kord.extensions.commands.events.*
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.i18n.EMPTY_VALUE_STRING
-import com.kotlindiscord.kord.extensions.i18n.TranslationsProvider
 import com.kotlindiscord.kord.extensions.parser.StringParser
 import com.kotlindiscord.kord.extensions.sentry.BreadcrumbType
-import com.kotlindiscord.kord.extensions.sentry.SentryAdapter
 import com.kotlindiscord.kord.extensions.sentry.tag
 import com.kotlindiscord.kord.extensions.sentry.user
 import com.kotlindiscord.kord.extensions.types.FailureReason
 import com.kotlindiscord.kord.extensions.utils.getLocale
-import com.kotlindiscord.kord.extensions.utils.permissionsForMember
 import com.kotlindiscord.kord.extensions.utils.respond
-import com.kotlindiscord.kord.extensions.utils.translate
 import dev.kord.common.entity.Permission
-import dev.kord.core.Kord
 import dev.kord.core.entity.channel.DmChannel
-import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.entity.channel.GuildMessageChannel
 import dev.kord.core.event.message.MessageCreateEvent
 import mu.KotlinLogging
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 import java.util.*
 
 private val logger = KotlinLogging.logger {}
@@ -58,21 +49,7 @@ private val logger = KotlinLogging.logger {}
 public open class ChatCommand<T : Arguments>(
     extension: Extension,
     public open val arguments: (() -> T)? = null
-) : Command(extension), KoinComponent {
-    /** Translations provider, for retrieving translations. **/
-    public val translationsProvider: TranslationsProvider by inject()
-
-    /** Bot settings object. **/
-    public val settings: ExtensibleBotBuilder by inject()
-
-    /** Message command registry. **/
-    public val registry: ChatCommandRegistry by inject()
-
-    /** Sentry adapter, for easy access to Sentry functions. **/
-    public val sentry: SentryAdapter by inject()
-
-    /** Kord instance, backing the ExtensibleBot. **/
-    public val kord: Kord by inject()
+) : Command(extension) {
 
     /**
      * @suppress
@@ -132,12 +109,6 @@ public open class ChatCommand<T : Arguments>(
      * @suppress
      */
     public open val checkList: MutableList<Check<MessageCreateEvent>> = mutableListOf()
-
-    /** Permissions required to be able to run this command. **/
-    public open val requiredPerms: MutableSet<Permission> = mutableSetOf()
-
-    /** Translation cache, so we don't have to look up translations every time. **/
-    public open val nameTranslationCache: MutableMap<Locale, String> = mutableMapOf()
 
     /** Translation cache, so we don't have to look up translations every time. **/
     public open val aliasTranslationCache: MutableMap<Locale, Set<String>> = mutableMapOf()
@@ -346,34 +317,6 @@ public open class ChatCommand<T : Arguments>(
         }
 
         return true
-    }
-
-    /** Checks whether the bot has the specified required permissions, throwing if it doesn't. **/
-    @Throws(DiscordRelayedException::class)
-    public open suspend fun checkBotPerms(context: ChatCommandContext<T>) {
-        if (requiredPerms.isEmpty()) {
-            return  // Nothing to check, don't try to hit the cache
-        }
-
-        if (context.guild != null) {
-            val perms = (context.channel.asChannel() as GuildChannel)
-                .permissionsForMember(kord.selfId)
-
-            val missingPerms = requiredPerms.filter { !perms.contains(it) }
-
-            if (missingPerms.isNotEmpty()) {
-                throw DiscordRelayedException(
-                    context.translate(
-                        "commands.error.missingBotPermissions",
-                        null,
-
-                        replacements = arrayOf(
-                            missingPerms.map { it.translate(context.getLocale()) }.joinToString(", ")
-                        )
-                    )
-                )
-            }
-        }
     }
 
     /**

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/chat/ChatCommandRegistry.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/chat/ChatCommandRegistry.kt
@@ -48,7 +48,7 @@ public open class ChatCommandRegistry : KoinComponent {
      * Directly register a [ChatCommand] to this command registry.
      *
      * Generally speaking, you shouldn't call this directly - instead, create an [Extension] and
-     * call the [Extension.messageContentCommand] function in your [Extension.setup] function.
+     * call the [ChatGroupCommand.chatCommand] function in your [Extension.setup] function.
      *
      * This function will throw a [CommandRegistrationException] if the command has already been registered, if
      * a command with the same name exists, or if a command with one of the same aliases exists.

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/ChannelConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/ChannelConverter.kt
@@ -82,7 +82,7 @@ public class ChannelConverter(
         val arg: String = named ?: parser?.parseNext()?.data ?: return false
 
         if (arg.equals("this", true)) {
-            val channel = context.getChannel()?.asChannelOrNull()
+            val channel = context.getChannel().asChannelOrNull()
 
             if (channel != null) {
                 this.parsed = channel

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/components/ComponentContext.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/components/ComponentContext.kt
@@ -152,6 +152,9 @@ public abstract class ComponentContext<E : ComponentInteractionCreateEvent>(
         replacements
     )
 
+    /**
+     * @param breadcrumb breadcrumb data will be modified to add the component context information
+     */
     public suspend fun addContextDataToBreadcrumb(breadcrumb: Breadcrumb) {
         val channel = channel.asChannelOrNull()
         val guild = guild?.asGuildOrNull()

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/components/ComponentContext.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/components/ComponentContext.kt
@@ -22,7 +22,10 @@ import dev.kord.core.behavior.UserBehavior
 import dev.kord.core.behavior.channel.MessageChannelBehavior
 import dev.kord.core.entity.Member
 import dev.kord.core.entity.Message
+import dev.kord.core.entity.channel.DmChannel
+import dev.kord.core.entity.channel.GuildMessageChannel
 import dev.kord.core.event.interaction.ComponentInteractionCreateEvent
+import io.sentry.Breadcrumb
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.*
@@ -59,8 +62,8 @@ public abstract class ComponentContext<E : ComponentInteractionCreateEvent>(
     /** Member that interacted with this component, if on a guild. **/
     public open var member: MemberBehavior? = null
 
-    /** Member that interacted with this component, if on a guild. **/
-    public open var message: Message? = null
+    /** The message the component is attached to. **/
+    public open lateinit var message: Message
 
     /** User that interacted with this component. **/
     public open lateinit var user: UserBehavior
@@ -86,12 +89,12 @@ public abstract class ComponentContext<E : ComponentInteractionCreateEvent>(
 
     /** Extract member information from event data, if that context is available. **/
     @JvmName("getMember1")
-    public suspend fun getMember(): MemberBehavior? =
+    public fun getMember(): MemberBehavior? =
         getGuild()?.let { Member(event.interaction.data.member.value!!, event.interaction.user.data, event.kord) }
 
     /** Extract message information from event data, if that context is available. **/
     @JvmName("getMessage1")
-    public fun getMessage(): Message? =
+    public fun getMessage(): Message =
         event.interaction.message
 
     /** Extract user information from event data, if that context is available. **/
@@ -148,4 +151,25 @@ public abstract class ComponentContext<E : ComponentInteractionCreateEvent>(
         component.bundle,
         replacements
     )
+
+    public suspend fun addContextDataToBreadcrumb(breadcrumb: Breadcrumb) {
+        val channel = channel.asChannelOrNull()
+        val guild = guild?.asGuildOrNull()
+        val message = message
+
+        if (channel != null) {
+            breadcrumb.data["channel"] = when (channel) {
+                is DmChannel -> "Private Message (${channel.id})"
+                is GuildMessageChannel -> "#${channel.name} (${channel.id})"
+
+                else -> channel.id.toString()
+            }
+        }
+
+        if (guild != null) {
+            breadcrumb.data["guild"] = "${guild.name} (${guild.id})"
+        }
+
+        breadcrumb.data["message"] = message.id.toString()
+    }
 }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/components/ComponentWithAction.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/components/ComponentWithAction.kt
@@ -12,11 +12,8 @@ import com.kotlindiscord.kord.extensions.checks.types.CheckContext
 import com.kotlindiscord.kord.extensions.components.callbacks.ComponentCallbackRegistry
 import com.kotlindiscord.kord.extensions.types.Lockable
 import com.kotlindiscord.kord.extensions.utils.getLocale
-import com.kotlindiscord.kord.extensions.utils.permissionsForMember
 import com.kotlindiscord.kord.extensions.utils.scheduling.Task
-import com.kotlindiscord.kord.extensions.utils.translate
 import dev.kord.common.entity.Permission
-import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.event.interaction.ComponentInteractionCreateEvent
 import kotlinx.coroutines.sync.Mutex
 import mu.KLogger
@@ -129,34 +126,6 @@ public abstract class ComponentWithAction<E : ComponentInteractionCreateEvent, C
     @Throws(DiscordRelayedException::class)
     public open suspend fun runChecks(event: E): Boolean =
         runStandardChecks(event)
-
-    /** Checks whether the bot has the specified required permissions, throwing if it doesn't. **/
-    @Throws(DiscordRelayedException::class)
-    public open suspend fun checkBotPerms(context: C) {
-        if (requiredPerms.isEmpty()) {
-            return  // Nothing to check, don't try to hit the cache
-        }
-
-        if (context.guild != null) {
-            val perms = (context.channel.asChannel() as GuildChannel)
-                .permissionsForMember(kord.selfId)
-
-            val missingPerms = requiredPerms.filter { !perms.contains(it) }
-
-            if (missingPerms.isNotEmpty()) {
-                throw DiscordRelayedException(
-                    context.translate(
-                        "commands.error.missingBotPermissions",
-                        null,
-
-                        replacements = arrayOf(
-                            missingPerms.map { it.translate(context.getLocale()) }.joinToString(", ")
-                        )
-                    )
-                )
-            }
-        }
-    }
 
     /** Override this to implement your component's calling logic. Check subtypes for examples! **/
     public open suspend fun call(event: E) {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/components/ComponentWithAction.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/components/ComponentWithAction.kt
@@ -12,8 +12,11 @@ import com.kotlindiscord.kord.extensions.checks.types.CheckContext
 import com.kotlindiscord.kord.extensions.components.callbacks.ComponentCallbackRegistry
 import com.kotlindiscord.kord.extensions.types.Lockable
 import com.kotlindiscord.kord.extensions.utils.getLocale
+import com.kotlindiscord.kord.extensions.utils.permissionsForMember
 import com.kotlindiscord.kord.extensions.utils.scheduling.Task
+import com.kotlindiscord.kord.extensions.utils.translate
 import dev.kord.common.entity.Permission
+import dev.kord.core.entity.channel.GuildChannel
 import dev.kord.core.event.interaction.ComponentInteractionCreateEvent
 import kotlinx.coroutines.sync.Mutex
 import mu.KLogger
@@ -126,6 +129,34 @@ public abstract class ComponentWithAction<E : ComponentInteractionCreateEvent, C
     @Throws(DiscordRelayedException::class)
     public open suspend fun runChecks(event: E): Boolean =
         runStandardChecks(event)
+
+    /** Checks whether the bot has the specified required permissions, throwing if it doesn't. **/
+    @Throws(DiscordRelayedException::class)
+    public open suspend fun checkBotPerms(context: C) {
+        if (requiredPerms.isEmpty()) {
+            return  // Nothing to check, don't try to hit the cache
+        }
+
+        if (context.guild != null) {
+            val perms = (context.channel.asChannel() as GuildChannel)
+                .permissionsForMember(kord.selfId)
+
+            val missingPerms = requiredPerms.filter { !perms.contains(it) }
+
+            if (missingPerms.isNotEmpty()) {
+                throw DiscordRelayedException(
+                    context.translate(
+                        "commands.error.missingBotPermissions",
+                        null,
+
+                        replacements = arrayOf(
+                            missingPerms.map { it.translate(context.getLocale()) }.joinToString(", ")
+                        )
+                    )
+                )
+            }
+        }
+    }
 
     /** Override this to implement your component's calling logic. Check subtypes for examples! **/
     public open suspend fun call(event: E) {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/components/buttons/InteractionButtonWithAction.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/components/buttons/InteractionButtonWithAction.kt
@@ -15,7 +15,6 @@ import com.kotlindiscord.kord.extensions.types.FailureReason
 import com.kotlindiscord.kord.extensions.utils.scheduling.Task
 import dev.kord.common.entity.DiscordPartialEmoji
 import dev.kord.core.entity.channel.DmChannel
-import dev.kord.core.entity.channel.GuildMessageChannel
 import dev.kord.core.event.interaction.ButtonInteractionCreateEvent
 import io.sentry.Sentry
 import mu.KLogger
@@ -51,28 +50,8 @@ public abstract class InteractionButtonWithAction<C : InteractionButtonContext>(
                 category = "component.button"
                 message = "Button \"${button.id}\" clicked."
 
-                val channel = context.channel.asChannelOrNull()
-                val guild = context.guild?.asGuildOrNull()
-                val message = context.message
-
                 data["component"] = button.id
-
-                if (channel != null) {
-                    data["channel"] = when (channel) {
-                        is DmChannel -> "Private Message (${channel.id})"
-                        is GuildMessageChannel -> "#${channel.name} (${channel.id})"
-
-                        else -> channel.id.toString()
-                    }
-                }
-
-                if (guild != null) {
-                    data["guild"] = "${guild.name} (${guild.id})"
-                }
-
-                if (message != null) {
-                    data["message"] = message.id.toString()
-                }
+                context.addContextDataToBreadcrumb(this)
             }
         }
     }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/components/menus/SelectMenu.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/components/menus/SelectMenu.kt
@@ -13,7 +13,6 @@ import com.kotlindiscord.kord.extensions.sentry.user
 import com.kotlindiscord.kord.extensions.types.FailureReason
 import com.kotlindiscord.kord.extensions.utils.scheduling.Task
 import dev.kord.core.entity.channel.DmChannel
-import dev.kord.core.entity.channel.GuildMessageChannel
 import dev.kord.core.event.interaction.SelectMenuInteractionCreateEvent
 import dev.kord.rest.builder.component.ActionRowBuilder
 import dev.kord.rest.builder.component.SelectOptionBuilder
@@ -131,28 +130,8 @@ public abstract class SelectMenu<C : SelectMenuContext>(
                 category = "component.selectMenu"
                 message = "Select menu \"${button.id}\" submitted."
 
-                val channel = context.channel.asChannelOrNull()
-                val guild = context.guild?.asGuildOrNull()
-                val message = context.message
-
                 data["component"] = button.id
-
-                if (channel != null) {
-                    data["channel"] = when (channel) {
-                        is DmChannel -> "Private Message (${channel.id})"
-                        is GuildMessageChannel -> "#${channel.name} (${channel.id})"
-
-                        else -> channel.id.toString()
-                    }
-                }
-
-                if (guild != null) {
-                    data["guild"] = "${guild.name} (${guild.id})"
-                }
-
-                if (message != null) {
-                    data["message"] = message.id.toString()
-                }
+                context.addContextDataToBreadcrumb(this)
             }
         }
     }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/extensions/_Commands.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/extensions/_Commands.kt
@@ -447,7 +447,7 @@ public suspend fun Extension.chatCommand(
  *
  * You can use this if you have a custom command subclass you need to register.
  *
- * @param commandObj MessageContentCommand object to register.
+ * @param commandObj [ChatCommand] object to register.
  */
 @ExtensionDSL
 public fun <T : Arguments> Extension.chatCommand(

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Message.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Message.kt
@@ -480,7 +480,7 @@ public suspend fun CommandContext.waitForResponse(
     val kord = com.kotlindiscord.kord.extensions.utils.getKoin().get<Kord>()
     val event = kord.waitFor<MessageCreateEvent>(timeout) {
         message.author?.id == getUser()?.id &&
-            message.channelId == getChannel()?.id &&
+            message.channelId == getChannel().id &&
             filter()
     }
 


### PR DESCRIPTION
Motivation: abstracting duplicate code leads to less code to maintain, less chance to miss one place.
I also added some quick documentation/type fixes that I found along the way.
I'll try to put these in separate pr's in the future :>