### PR TITLE
Fix CCE: Pair -> MemberEntry

### DIFF
--- a/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/MappingsExtension.kt
+++ b/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/MappingsExtension.kt
@@ -34,12 +34,10 @@ import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.withContext
 import me.shedaniel.linkie.*
 import me.shedaniel.linkie.namespaces.*
-import me.shedaniel.linkie.utils.MappingsQuery
-import me.shedaniel.linkie.utils.QueryContext
-import me.shedaniel.linkie.utils.QueryResult
-import me.shedaniel.linkie.utils.ResultHolder
+import me.shedaniel.linkie.utils.*
 import mu.KotlinLogging
 import kotlin.collections.set
+import kotlin.error
 
 private typealias MappingSlashCommand = PublicSlashCommandContext<out MappingArguments>
 private typealias ConversionSlashCommand = PublicSlashCommandContext<MappingConversionArguments>
@@ -952,15 +950,15 @@ class MappingsExtension : Extension() {
                             desc == inputDesc
                         }!!
 
-                        clazz to result
+                        MemberEntry<MappingsMember>(clazz, result)
                     } catch (e: NullPointerException) {
                         null // skip
                     }
                 }
                     .filterValues { it != null }
-                    .mapValues {
+                    .mapValues { (_, value) ->
                         @Suppress("UNCHECKED_CAST")
-                        it.value!! as B
+                        value as B
                     }
 
                 sentry.breadcrumb(BreadcrumbType.Info) {


### PR DESCRIPTION
why can't kotlin just provide dummy interfaces that are applied behind the scenes at compile time to all data classes which provide the appropriate `componentN` functions

then `Pair` and `MemberEntry` would both be implementing `Component2<A, B>` and therefore no CCE would've occurred

maybe i should do questionable ASM for that to occur