### PR TITLE
Fix localized slash commands & groups

### DIFF
--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/ApplicationCommandRegistry.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/ApplicationCommandRegistry.kt
@@ -430,9 +430,11 @@ public abstract class ApplicationCommandRegistry : KordExKoinComponent {
             }
 
             command.groups.values.sortedByDescending { it.name }.forEach { group ->
-                this.group(group.name, group.description) {
-                    this.nameLocalizations = group.localizedName.translations
-                    this.descriptionLocalizations = group.localizedDescription.translations
+                val (name, nameLocalizations) = group.localizedName
+                val (description, descriptionLocalizations) = group.localizedDescription
+                this.group(name, description) {
+                    this.nameLocalizations = nameLocalizations
+                    this.descriptionLocalizations = descriptionLocalizations
 
                     group.subCommands.sortedByDescending { it.name }.forEach {
                         val args = it.arguments?.invoke()?.args?.map { arg ->

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/SlashCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/SlashCommand.kt
@@ -207,7 +207,7 @@ public abstract class SlashCommand<C : SlashCommandContext<*, A>, A : Arguments>
             is SubCommand -> {
                 val firstSubCommandKey = eventCommand.name
 
-                this.subCommands.firstOrNull { it.name == firstSubCommandKey }
+                this.subCommands.firstOrNull { it.localizedName.default == firstSubCommandKey }
                     ?: error("Unknown subcommand: $firstSubCommandKey")
             }
 
@@ -216,7 +216,7 @@ public abstract class SlashCommand<C : SlashCommandContext<*, A>, A : Arguments>
                 val group = this.groups[firstEventGroupKey] ?: error("Unknown command group: $firstEventGroupKey")
                 val firstSubCommandKey = eventCommand.name
 
-                group.subCommands.firstOrNull { it.name == firstSubCommandKey }
+                group.subCommands.firstOrNull { it.localizedName.default == firstSubCommandKey }
                     ?: error("Unknown subcommand: $firstSubCommandKey")
             }
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/_Functions.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/_Functions.kt
@@ -38,7 +38,9 @@ public suspend fun SlashCommand<*, *>.group(name: String, body: suspend SlashGro
         error("Commands may only contain up to $SUBCOMMAND_AND_GROUP_LIMIT command groups.")
     }
 
-    if (groups[name] != null) {
+    val localizedGroupName = localize(name, true).default
+
+    if (groups[localizedGroupName] != null) {
         error("A command group with the name '$name' has already been registered.")
     }
 
@@ -47,7 +49,7 @@ public suspend fun SlashCommand<*, *>.group(name: String, body: suspend SlashGro
     body(group)
     group.validate()
 
-    groups[name] = group
+    groups[localizedGroupName] = group
 
     return group
 }

--- a/kord-extensions/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/TestExtension.kt
+++ b/kord-extensions/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/TestExtension.kt
@@ -178,13 +178,13 @@ class TestExtension : Extension() {
         }
 
         publicSlashCommand {
-            name = "banana"
-            description = "banana"
+            name = "command.banana"
+            description = "command.banana"
 
             bundle = "test"
 
             action {
-                respond { content = "Text: ${translate("banana")}" }
+                respond { content = "Text: ${translate("command.banana")}" }
             }
         }
 

--- a/test-bot/src/main/kotlin/com/kotlindiscord/kord/extensions/testbot/extensions/I18nTestExtension.kt
+++ b/test-bot/src/main/kotlin/com/kotlindiscord/kord/extensions/testbot/extensions/I18nTestExtension.kt
@@ -20,7 +20,7 @@ public class I18nTestExtension : Extension() {
 
     override suspend fun setup() {
         publicSlashCommand {
-            name = "banana-flat"
+            name = "command.banana-flat"
             description = "Translated banana"
 
             action {
@@ -31,16 +31,16 @@ public class I18nTestExtension : Extension() {
                     "Command locale (`$commandLocale`) does not match interaction locale (`$interactionLocale`)"
                 }
 
-                respond { content = "Text: ${translate("banana")}" }
+                respond { content = "Text: ${translate("command.banana")}" }
             }
         }
 
         publicSlashCommand {
-            name = "banana-sub"
+            name = "command.banana-sub"
             description = "Translated banana subcommand"
 
             publicSubCommand {
-                name = "banana"
+                name = "command.banana"
                 description = "Translated banana"
 
                 action {
@@ -51,20 +51,20 @@ public class I18nTestExtension : Extension() {
                         "Command locale (`$commandLocale`) does not match interaction locale (`$interactionLocale`)"
                     }
 
-                    respond { content = "Text: ${translate("banana")}" }
+                    respond { content = "Text: ${translate("command.banana")}" }
                 }
             }
         }
 
         publicSlashCommand {
-            name = "banana-group"
+            name = "command.banana-group"
             description = "Translated banana group"
 
-            group("banana") {
+            group("command.banana") {
                 description = "Translated banana group"
 
                 publicSubCommand {
-                    name = "banana"
+                    name = "command.banana"
                     description = "Translated banana"
 
                     action {
@@ -75,7 +75,7 @@ public class I18nTestExtension : Extension() {
                             "Command locale (`$commandLocale`) does not match interaction locale (`$interactionLocale`)"
                         }
 
-                        respond { content = "Text: ${translate("banana")}" }
+                        respond { content = "Text: ${translate("command.banana")}" }
                     }
                 }
             }

--- a/test-bot/src/main/resources/translations/test/strings.properties
+++ b/test-bot/src/main/resources/translations/test/strings.properties
@@ -4,7 +4,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
 
-banana=banana
-banana-flat=banana-flat
-banana-sub=banana-sub
-banana-group=banana-group
+command.banana=banana
+command.banana-flat=banana-flat
+command.banana-sub=banana-sub
+command.banana-group=banana-group

--- a/test-bot/src/main/resources/translations/test/strings_de.properties
+++ b/test-bot/src/main/resources/translations/test/strings_de.properties
@@ -4,7 +4,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
 
-banana=Banane
-banana-flat=Banane-flat
-banana-sub=Banane-sub
-banana-group=Banane-group
+command.banana=banane
+command.banana-flat=banane-flat
+command.banana-sub=banane-sub
+command.banana-group=banane-group

--- a/test-bot/src/main/resources/translations/test/strings_en_GB.properties
+++ b/test-bot/src/main/resources/translations/test/strings_en_GB.properties
@@ -4,7 +4,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
 
-banana=banana
-banana-flat=banana-flat
-banana-sub=banana-sub
-banana-group=banana-group
+command.banana=banana
+command.banana-flat=banana-flat
+command.banana-sub=banana-sub
+command.banana-group=banana-group

--- a/test-bot/src/main/resources/translations/test/strings_en_US.properties
+++ b/test-bot/src/main/resources/translations/test/strings_en_US.properties
@@ -4,7 +4,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
 
-banana=banana
-banana-flat=banana-flat
-banana-sub=banana-sub
-banana-group=banana-group
+command.banana=banana
+command.banana-flat=banana-flat
+command.banana-sub=banana-sub
+command.banana-group=banana-group

--- a/test-bot/src/main/resources/translations/test/strings_ja.properties
+++ b/test-bot/src/main/resources/translations/test/strings_ja.properties
@@ -4,7 +4,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
 
-banana=バナナ
-banana-flat=バナナ-flat
-banana-sub=バナナ-sub
-banana-group=バナナ-group
+command.banana=バナナ
+command.banana-flat=バナナ-flat
+command.banana-sub=バナナ-sub
+command.banana-group=バナナ-group

--- a/test-bot/src/main/resources/translations/test/strings_zh_CN.properties
+++ b/test-bot/src/main/resources/translations/test/strings_zh_CN.properties
@@ -4,7 +4,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #
 
-banana=香蕉
-banana-flat=香蕉-flat
-banana-sub=香蕉-sub
-banana-group=香蕉-group
+command.banana=香蕉
+command.banana-flat=香蕉-flat
+command.banana-sub=香蕉-sub
+command.banana-group=香蕉-group


### PR DESCRIPTION
<!--
Hello, and thanks for submitting a pull request! To help us address this PR
quickly, please take the time to fill out this template to the best of
your ability, and please provide as much information as possible!

When you're done, feel free to remove these comments if you like.

Additionally, please remember that PRs are not the place to disclose
a security issue. Instead, please contact a member of our admin team directly
on Discord, or send a private message to the ModMail bot there.

This doesn't mean that you can't contribute to security fixes - we just
require that they be contributed as part of a proper security advisory, so
that they can be worked on without risking wider exposure of the vulnerability
before it is fixed.
-->

# Relevant Issues
#158

# Description

Discord is not able to handle localization keys as subcommand or group names when using localized subcommands/groups.
So now we just send them the default translation for the name instead of the translation key beside the translations.

I also updated the test bot to not have the same translation keys as translations because this caused to not be able to reproduce the bug described in #158
