### PR TITLE
Fix printVersion task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,9 @@ group = "com.kotlindiscord.kord.extensions"
 version = projectVersion
 
 val printVersion = task("printVersion") {
-    print(version.toString())
+    doLast {
+        print(version.toString())
+    }
 }
 
 gitHooks {


### PR DESCRIPTION
<!--
Hello, and thanks for submitting a pull request! To help us address this PR
quickly, please take the time to fill out this template to the best of
your ability, and please provide as much information as possible!

When you're done, feel free to remove these comments if you like.

Additionally, please remember that PRs are not the place to disclose
a security issue. Instead, please contact a member of our admin team directly
on Discord, or send a private message to the ModMail bot there.

This doesn't mean that you can't contribute to security fixes - we just
require that they be contributed as part of a proper security advisory, so
that they can be worked on without risking wider exposure of the vulnerability
before it is fixed.
-->

# Description

I noticed the printVersion task is defined wrong. Its content gets executed everytime the buildscript gets ran.
Now it just prints when the task gets executed.

