### PR TITLE
Fix option registration

### DIFF
--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/Argument.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/Argument.kt
@@ -7,6 +7,7 @@
 package com.kotlindiscord.kord.extensions.commands
 
 import com.kotlindiscord.kord.extensions.commands.converters.Converter
+import com.kotlindiscord.kord.extensions.i18n.TranslationsProvider
 
 /**
  * Data class representing a single argument.
@@ -18,9 +19,12 @@ import com.kotlindiscord.kord.extensions.commands.converters.Converter
 public data class Argument<T : Any?>(
     val displayName: String,
     val description: String,
-    val converter: Converter<T, *, *, *>
+    val converter: Converter<T, *, *, *>,
 ) {
     init {
         converter.argumentObj = this
     }
 }
+
+internal fun Argument<*>.getDefaultTranslatedDisplayName(provider: TranslationsProvider, command: Command): String =
+    provider.translate(displayName, provider.defaultLocale, command.resolvedBundle)

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/DefaultApplicationCommandRegistry.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/DefaultApplicationCommandRegistry.kt
@@ -16,6 +16,7 @@ package com.kotlindiscord.kord.extensions.commands.application
 import com.kotlindiscord.kord.extensions.commands.application.message.MessageCommand
 import com.kotlindiscord.kord.extensions.commands.application.slash.SlashCommand
 import com.kotlindiscord.kord.extensions.commands.application.user.UserCommand
+import com.kotlindiscord.kord.extensions.commands.getDefaultTranslatedDisplayName
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.behavior.createApplicationCommands
 import dev.kord.core.event.interaction.AutoCompleteInteractionCreateEvent
@@ -85,7 +86,7 @@ public open class DefaultApplicationCommandRegistry : ApplicationCommandRegistry
                         if (e.error?.code == JsonErrorCode.MissingAccess) {
                             append(
                                 "\n        Double-check that the bot was added to this guild with the " +
-                                "`application.commands` scope enabled"
+                                    "`application.commands` scope enabled"
                             )
                         }
                     }
@@ -112,7 +113,7 @@ public open class DefaultApplicationCommandRegistry : ApplicationCommandRegistry
     public open suspend fun sync(
         removeOthers: Boolean = false,
         guildId: Snowflake?,
-        commands: List<ApplicationCommand<*>>
+        commands: List<ApplicationCommand<*>>,
     ) {
         // NOTE: Someday, discord will make real i18n possible, we hope...
         val locale = bot.settings.i18nBuilder.defaultLocale
@@ -165,14 +166,14 @@ public open class DefaultApplicationCommandRegistry : ApplicationCommandRegistry
                 if (guild == null) {
                     append(
                         "Global application commands: ${toAdd.size} to add / " +
-                        "${toUpdate.size} to update / " +
-                        "${toRemove.size} to remove"
+                            "${toUpdate.size} to update / " +
+                            "${toRemove.size} to remove"
                     )
                 } else {
                     append(
                         "Application commands for guild ${guild.name}: ${toAdd.size} to add / " +
-                        "${toUpdate.size} to update / " +
-                        "${toRemove.size} to remove"
+                            "${toUpdate.size} to update / " +
+                            "${toRemove.size} to remove"
                     )
                 }
 
@@ -219,7 +220,7 @@ public open class DefaultApplicationCommandRegistry : ApplicationCommandRegistry
             kord.createGlobalApplicationCommands { builder() }.toList()
         } else {
             // We're registering guild-specific commands here, if the guild is available
-            guild.createApplicationCommands  { builder() }.toList()
+            guild.createApplicationCommands { builder() }.toList()
         }
 
         // Next, we need to associate all the commands we just registered with the commands in our extensions
@@ -377,7 +378,9 @@ public open class DefaultApplicationCommandRegistry : ApplicationCommandRegistry
 
         option ?: return logger.trace { "Autocomplete event for command $command doesn't have a focused option." }
 
-        val arg = command.arguments!!().args.firstOrNull { it.displayName == option.first }
+        val arg = command.arguments!!().args.firstOrNull {
+            it.getDefaultTranslatedDisplayName(translationsProvider, command) == option.first
+        }
 
         arg ?: return logger.warn {
             "Autocomplete event for command $command has an unknown focused option: ${option.first}."

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/SlashCommandParser.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/SlashCommandParser.kt
@@ -16,6 +16,7 @@ import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.converters.*
+import com.kotlindiscord.kord.extensions.commands.getDefaultTranslatedDisplayName
 import dev.kord.common.annotation.KordPreview
 import dev.kord.core.entity.interaction.OptionValue
 import dev.kord.core.entity.interaction.StringOptionValue
@@ -38,7 +39,7 @@ public open class SlashCommandParser {
      */
     public suspend fun <T : Arguments> parse(
         builder: () -> T,
-        context: SlashCommandContext<*, *>
+        context: SlashCommandContext<*, *>,
     ): T {
         val argumentsObj = builder.invoke()
         argumentsObj.validate()
@@ -66,7 +67,8 @@ public open class SlashCommandParser {
 
             logger.trace { "Current argument: ${currentArg.displayName}" }
 
-            currentValue = values[currentArg.displayName.lowercase()]
+            currentValue =
+                values[currentArg.getDefaultTranslatedDisplayName(context.translationsProvider, context.command)]
 
             logger.trace { "Current value: $currentValue" }
 

--- a/test-bot/src/main/kotlin/com/kotlindiscord/kord/extensions/testbot/extensions/I18nTestExtension.kt
+++ b/test-bot/src/main/kotlin/com/kotlindiscord/kord/extensions/testbot/extensions/I18nTestExtension.kt
@@ -8,11 +8,14 @@
 
 package com.kotlindiscord.kord.extensions.testbot.extensions
 
+import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.application.slash.group
 import com.kotlindiscord.kord.extensions.commands.application.slash.publicSubCommand
+import com.kotlindiscord.kord.extensions.commands.converters.impl.string
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
 import com.kotlindiscord.kord.extensions.types.respond
+import dev.kord.core.behavior.interaction.suggestString
 
 public class I18nTestExtension : Extension() {
     override val name: String = "test-i18n"
@@ -78,6 +81,29 @@ public class I18nTestExtension : Extension() {
                         respond { content = "Text: ${translate("command.banana")}" }
                     }
                 }
+            }
+        }
+
+        publicSlashCommand(::I18nTestArguments) {
+            name = "command.fruit"
+            description = "command.fruit"
+
+            action {
+                respond {
+                    content = translate("command.fruit.response", arrayOf(arguments.fruit))
+                }
+            }
+        }
+    }
+}
+
+internal class I18nTestArguments : Arguments() {
+    val fruit by string {
+        name = "command.fruit"
+        description = "command.fruit"
+        autoComplete {
+            suggestString {
+                listOf("Banana", "Apple", "Cherry").forEach { choice(it, it) }
             }
         }
     }

--- a/test-bot/src/main/resources/translations/test/strings.properties
+++ b/test-bot/src/main/resources/translations/test/strings.properties
@@ -8,3 +8,5 @@ command.banana=banana
 command.banana-flat=banana-flat
 command.banana-sub=banana-sub
 command.banana-group=banana-group
+command.fruit=fruit
+command.fruit.response=my favorite fruit is {0}

--- a/test-bot/src/main/resources/translations/test/strings_de.properties
+++ b/test-bot/src/main/resources/translations/test/strings_de.properties
@@ -8,3 +8,5 @@ command.banana=banane
 command.banana-flat=banane-flat
 command.banana-sub=banane-sub
 command.banana-group=banane-group
+command.fruit=frucht
+command.fruit.response=Meine Lieblingsfrucht ist: {0}

--- a/test-bot/src/main/resources/translations/test/strings_en_GB.properties
+++ b/test-bot/src/main/resources/translations/test/strings_en_GB.properties
@@ -8,3 +8,5 @@ command.banana=banana
 command.banana-flat=banana-flat
 command.banana-sub=banana-sub
 command.banana-group=banana-group
+command.fruit=fruit
+command.fruit.response=my favorite fruit is {0}

--- a/test-bot/src/main/resources/translations/test/strings_en_US.properties
+++ b/test-bot/src/main/resources/translations/test/strings_en_US.properties
@@ -8,3 +8,5 @@ command.banana=banana
 command.banana-flat=banana-flat
 command.banana-sub=banana-sub
 command.banana-group=banana-group
+command.fruit=fruit
+command.fruit.response=my favorite fruit is {0}


### PR DESCRIPTION
<!--
Hello, and thanks for submitting a pull request! To help us address this PR
quickly, please take the time to fill out this template to the best of
your ability, and please provide as much information as possible!

When you're done, feel free to remove these comments if you like.

Additionally, please remember that PRs are not the place to disclose
a security issue. Instead, please contact a member of our admin team directly
on Discord, or send a private message to the ModMail bot there.

This doesn't mean that you can't contribute to security fixes - we just
require that they be contributed as part of a proper security advisory, so
that they can be worked on without risking wider exposure of the vulnerability
before it is fixed.
-->

# Description
Slash command options were registered with their default translation, but then compared to their translation key.
This behavior broke option autocomplete. See media. This PR fixes that by comparing to the default translation.

# Media
## Before
[Peek 2022-07-11 01-35.webm](https://user-images.githubusercontent.com/37078297/178166725-741ac924-a2f9-4eaf-8417-0add1a871a0c.webm)

## After
[Peek 2022-07-11 01-47.webm](https://user-images.githubusercontent.com/37078297/178166747-db6bd567-89ab-4b46-a033-ed9729a89fe5.webm)
