### PR TITLE
Add Manage Webhooks permission requirement to PK Module readme

### DIFF
--- a/extra-modules/extra-pluralkit/README.md
+++ b/extra-modules/extra-pluralkit/README.md
@@ -36,6 +36,8 @@ suspend fun main() {
 This will install the extension using its default configuration. However, the extension may be configured in several 
 ways - as is detailed below.
 
+Your bot will now require the **Manage Webhooks** permission to use the extension.
+
 # Commands
 
 This extension provides the following commands for use on Discord.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Thu May 07 11:13:09 BST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-rc-4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This module requires the Manage Webhook permission to avoid the internal `MessageCreateEvent` producing `KtorRequestExceptions` claiming there are missing permissions. This PR details this in the README.md of the module.

While I was there I updated gradle to 7.5