### PR TITLE
Properly register dmPermission for global commands

### DIFF
--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/ApplicationCommandRegistry.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/ApplicationCommandRegistry.kt
@@ -355,7 +355,7 @@ public abstract class ApplicationCommandRegistry : KordExKoinComponent {
     public open suspend fun ChatInputCreateBuilder.register(locale: Locale, command: SlashCommand<*, *>) {
         if (this is GlobalChatInputCreateBuilder) {
             registerGlobalPermissions(locale, command)
-        }else {
+        } else {
             registerGuildPermissions(locale, command)
         }
 
@@ -510,7 +510,7 @@ public abstract class ApplicationCommandRegistry : KordExKoinComponent {
      */
     public open fun GlobalApplicationCommandCreateBuilder.registerGlobalPermissions(
         locale: Locale,
-        command: ApplicationCommand<*>
+        command: ApplicationCommand<*>,
     ) {
         registerGuildPermissions(locale, command)
         this.dmPermission = command.allowInDms
@@ -521,7 +521,7 @@ public abstract class ApplicationCommandRegistry : KordExKoinComponent {
      */
     public open fun ApplicationCommandCreateBuilder.registerGuildPermissions(
         locale: Locale,
-        command: ApplicationCommand<*>
+        command: ApplicationCommand<*>,
     ) {
         this.defaultMemberPermissions = command.defaultMemberPermissions
     }
@@ -529,7 +529,7 @@ public abstract class ApplicationCommandRegistry : KordExKoinComponent {
     /** Check whether the type and name of an extension-registered application command matches a Discord one. **/
     public open fun ApplicationCommand<*>.matches(
         locale: Locale,
-        other: dev.kord.core.entity.application.ApplicationCommand
+        other: dev.kord.core.entity.application.ApplicationCommand,
     ): Boolean = type == other.type && localizedName.default.equals(other.name, true)
 
     // endregion

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/ApplicationCommandRegistry.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/ApplicationCommandRegistry.kt
@@ -351,17 +351,13 @@ public abstract class ApplicationCommandRegistry : KordExKoinComponent {
     // endregion
 
     // region: Extensions
-
-    /** Registration logic for slash commands, extracted for clarity. **/
-    public open suspend fun GlobalChatInputCreateBuilder.register(locale: Locale, command: SlashCommand<*, *>) {
-        registerGlobalPermissions(locale, command)
-
-        (this as ChatInputCreateBuilder).register(locale, command)
-    }
-
     /** Registration logic for slash commands, extracted for clarity. **/
     public open suspend fun ChatInputCreateBuilder.register(locale: Locale, command: SlashCommand<*, *>) {
-        registerGuildPermissions(locale, command)
+        if (this is GlobalChatInputCreateBuilder) {
+            registerGlobalPermissions(locale, command)
+        }else {
+            registerGuildPermissions(locale, command)
+        }
 
         if (command.hasBody) {
             val args = command.arguments?.invoke()


### PR DESCRIPTION
Since `GlobalChatInputCreateBuilder` inherits from `ChatInputCreateBuilder`, the `register` method for the parent class was always being called.

Since `GlobalChatInputCreateBuilder.register` was calling `ChatInputCreateBuilder.register` anyway, I think it's better to just add an if at the beginning to call `registerGlobalPermissions`

I added that `else` just to avoid calling `registerGuildPermissions` twice, since `registerGlobalPermissions` calls it too.

I tested it with `test-bot` but I did not commit those changes.