### PR TITLE
Fix EmojiConverter

### DIFF
--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/EmojiConverter.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/impl/EmojiConverter.kt
@@ -96,7 +96,7 @@ public class EmojiConverter(
                 }.firstOrNull()
             } catch (e: NumberFormatException) {  // Not an ID, let's check names
                 kord.guilds.mapNotNull {
-                    it.emojis.first { emojiObj -> emojiObj.name?.lowercase().equals(name, true) }
+                    it.emojis.firstOrNull { emojiObj -> emojiObj.name?.lowercase().equals(name, true) }
                 }.firstOrNull()
             }
         }


### PR DESCRIPTION
Broken logic, first will throw an exception, while the upper mapNotNull was expecting a null.

Closes #176 