### PR TITLE
Fix subcommands with arguments with null parent command

### DIFF
--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/_Functions.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/_Functions.kt
@@ -70,7 +70,7 @@ public suspend fun <T : Arguments> SlashCommand<*, *>.ephemeralSubCommand(
     arguments: () -> T,
     body: suspend EphemeralSlashCommand<T>.() -> Unit
 ): EphemeralSlashCommand<T> {
-    val commandObj = EphemeralSlashCommand(extension, arguments, parentCommand, parentGroup)
+    val commandObj = EphemeralSlashCommand(extension, arguments, this, parentGroup)
     body(commandObj)
 
     return ephemeralSubCommand(commandObj)
@@ -139,7 +139,7 @@ public suspend fun <T : Arguments> SlashCommand<*, *>.publicSubCommand(
     arguments: () -> T,
     body: suspend PublicSlashCommand<T>.() -> Unit
 ): PublicSlashCommand<T> {
-    val commandObj = PublicSlashCommand(extension, arguments, parentCommand, parentGroup)
+    val commandObj = PublicSlashCommand(extension, arguments, this, parentGroup)
     body(commandObj)
 
     return publicSubCommand(commandObj)

--- a/modules/unsafe/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/unsafe/extensions/_SlashCommands.kt
+++ b/modules/unsafe/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/unsafe/extensions/_SlashCommands.kt
@@ -33,7 +33,7 @@ public suspend fun <T : Arguments> SlashCommand<*, *>.unsafeSubCommand(
     arguments: () -> T,
     body: suspend UnsafeSlashCommand<T>.() -> Unit
 ): UnsafeSlashCommand<T> {
-    val commandObj = UnsafeSlashCommand(extension, arguments, parentCommand, parentGroup)
+    val commandObj = UnsafeSlashCommand(extension, arguments, this, parentGroup)
     body(commandObj)
 
     return unsafeSubCommand(commandObj)


### PR DESCRIPTION
The parent command of subcommands with arguments were not being set properly.