### PR TITLE
Add support for named arguments in translations

### DIFF
--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/types/CheckContext.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/types/CheckContext.kt
@@ -153,8 +153,30 @@ public open class CheckContext<out T : Event>(public val event: T, public val lo
     /** Quick access to translate strings using this check context's [locale]. **/
     public fun translate(
         key: String,
-        bundle: String? = defaultBundle,
+        bundle: String?,
         replacements: Array<Any?> = arrayOf()
+    ): String =
+        translations.translate(key, locale, bundleName = bundle, replacements = replacements)
+
+    /** Quick access to translate strings using this check context's [locale]. **/
+    public fun translate(
+        key: String,
+        replacements: Array<Any?> = arrayOf()
+    ): String =
+        translations.translate(key, locale, bundleName = defaultBundle, replacements = replacements)
+
+    /** Quick access to translate strings using this check context's [locale]. **/
+    public fun translate(
+        key: String,
+        replacements: Map<String, Any?>
+    ): String =
+        translations.translate(key, locale, bundleName = defaultBundle, replacements = replacements)
+
+    /** Quick access to translate strings using this check context's [locale]. **/
+    public fun translate(
+        key: String,
+        bundle: String?,
+        replacements: Map<String, Any?>
     ): String =
         translations.translate(key, locale, bundleName = bundle, replacements = replacements)
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/types/CheckContext.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/types/CheckContext.kt
@@ -153,7 +153,7 @@ public open class CheckContext<out T : Event>(public val event: T, public val lo
     /** Quick access to translate strings using this check context's [locale]. **/
     public fun translate(
         key: String,
-        bundle: String?,
+        bundle: String? = defaultBundle,
         replacements: Array<Any?> = arrayOf()
     ): String =
         translations.translate(key, locale, bundleName = bundle, replacements = replacements)

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/CommandContext.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/CommandContext.kt
@@ -106,10 +106,34 @@ public abstract class CommandContext(
     }
 
     /**
+     * Given a translation key and bundle name, return the translation for the locale provided by the bot's configured
+     * locale resolvers.
+     */
+    public suspend fun translate(
+        key: String,
+        bundleName: String?,
+        replacements: Map<String, Any?>
+    ): String {
+        val locale = getLocale()
+
+        return translationsProvider.translate(key, locale, bundleName, replacements)
+    }
+
+    /**
      * Given a translation key and possible replacements,return the translation for the given locale in the
      * extension's configured bundle, for the locale provided by the bot's configured locale resolvers.
      */
     public suspend fun translate(key: String, replacements: Array<Any?> = arrayOf()): String = translate(
+        key,
+        command.resolvedBundle,
+        replacements
+    )
+
+    /**
+     * Given a translation key and possible replacements,return the translation for the given locale in the
+     * extension's configured bundle, for the locale provided by the bot's configured locale resolvers.
+     */
+    public suspend fun translate(key: String, replacements: Map<String, Any?>): String = translate(
         key,
         command.resolvedBundle,
         replacements

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/CommandContext.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/CommandContext.kt
@@ -120,7 +120,7 @@ public abstract class CommandContext(
     }
 
     /**
-     * Given a translation key and possible replacements,return the translation for the given locale in the
+     * Given a translation key and possible replacements, return the translation for the given locale in the
      * extension's configured bundle, for the locale provided by the bot's configured locale resolvers.
      */
     public suspend fun translate(key: String, replacements: Array<Any?> = arrayOf()): String = translate(
@@ -130,7 +130,7 @@ public abstract class CommandContext(
     )
 
     /**
-     * Given a translation key and possible replacements,return the translation for the given locale in the
+     * Given a translation key and possible replacements, return the translation for the given locale in the
      * extension's configured bundle, for the locale provided by the bot's configured locale resolvers.
      */
     public suspend fun translate(key: String, replacements: Map<String, Any?>): String = translate(

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/chat/ChatCommandContext.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/chat/ChatCommandContext.kt
@@ -129,4 +129,13 @@ public open class ChatCommandContext<T : Arguments>(
         replacements: Array<Any?> = arrayOf(),
         useReply: Boolean = true
     ): Message = respond(translate(key, command.resolvedBundle, replacements), useReply)
+
+    /**
+     * Convenience function allowing for message responses with translated content.
+     */
+    public suspend fun Message.respondTranslated(
+        key: String,
+        replacements: Map<String, Any?>,
+        useReply: Boolean = true
+    ): Message = respond(translate(key, command.resolvedBundle, replacements), useReply)
 }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/ValidationContext.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/converters/builders/ValidationContext.kt
@@ -159,6 +159,28 @@ public class ValidationContext<out T>(public val value: T, public val context: C
     ): String =
         translations.translate(key, context.getLocale(), bundleName = bundle, replacements = replacements)
 
+    /** Quick access to translate strings using this validator context's [locale]. **/
+    public suspend fun translate(
+        key: String,
+        replacements: Array<Any?> = arrayOf()
+    ): String =
+        translations.translate(key, context.getLocale(), bundleName = defaultBundle, replacements = replacements)
+
+    /** Quick access to translate strings using this validator context's [locale]. **/
+    public suspend fun translate(
+        key: String,
+        replacements: Map<String, Any?>
+    ): String =
+        translations.translate(key, context.getLocale(), bundleName = defaultBundle, replacements = replacements)
+
+    /** Quick access to translate strings using this validator context's [locale]. **/
+    public suspend fun translate(
+        key: String,
+        bundle: String?,
+        replacements: Map<String, Any?>
+    ): String =
+        translations.translate(key, context.getLocale(), bundleName = bundle, replacements = replacements)
+
     /**
      * If this validator has failed, throw a [DiscordRelayedException] with the translated message, if any.
      */

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/components/ComponentContext.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/components/ComponentContext.kt
@@ -156,6 +156,30 @@ public abstract class ComponentContext<E : ComponentInteractionCreateEvent>(
     )
 
     /**
+     * Given a translation key and bundle name, return the translation for the locale provided by the bot's configured
+     * locale resolvers.
+     */
+    public suspend fun translate(
+        key: String,
+        bundleName: String?,
+        replacements: Map<String, Any?>
+    ): String {
+        val locale = getLocale()
+
+        return translationsProvider.translate(key, locale, bundleName, replacements)
+    }
+
+    /**
+     * Given a translation key and possible replacements, return the translation for the given locale in the
+     * component's configured bundle, for the locale provided by the bot's configured locale resolvers.
+     */
+    public suspend fun translate(key: String, replacements: Map<String, Any?>): String = translate(
+        key,
+        component.bundle,
+        replacements
+    )
+
+    /**
      * @param breadcrumb breadcrumb data will be modified to add the component context information
      */
     public suspend fun addContextDataToBreadcrumb(breadcrumb: Breadcrumb) {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/components/ComponentContext.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/components/ComponentContext.kt
@@ -146,7 +146,7 @@ public abstract class ComponentContext<E : ComponentInteractionCreateEvent>(
     }
 
     /**
-     * Given a translation key and possible replacements,return the translation for the given locale in the
+     * Given a translation key and possible replacements, return the translation for the given locale in the
      * component's configured bundle, for the locale provided by the bot's configured locale resolvers.
      */
     public suspend fun translate(key: String, replacements: Array<Any?> = arrayOf()): String = translate(

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventContext.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventContext.kt
@@ -47,21 +47,25 @@ public open class EventContext<T : Event>(
         bundleName: String?,
         replacements: Array<Any?> = arrayOf()
     ): String {
-        val eventObj = event as Event
-        var locale: Locale? = null
+        val locale: Locale? = resolveLocale()
 
-        val guild = guildFor(eventObj)
-        val channel = channelFor(eventObj)
-        val user = userFor(eventObj)
-
-        for (resolver in eventHandler.extension.bot.settings.i18nBuilder.localeResolvers) {
-            val result = resolver(guild, channel, user, interactionFor(eventObj))
-
-            if (result != null) {
-                locale = result
-                break
-            }
+        return if (locale != null) {
+            translationsProvider.translate(key, locale, bundleName, replacements)
+        } else {
+            translationsProvider.translate(key, bundleName, replacements)
         }
+    }
+
+    /**
+     * Given a translation key and optional bundle name, return the translation for the locale provided by the bot's
+     * configured locale resolvers.
+     */
+    public suspend fun translate(
+        key: String,
+        bundleName: String?,
+        replacements: Map<String, Any?>
+    ): String {
+        val locale: Locale? = resolveLocale()
 
         return if (locale != null) {
             translationsProvider.translate(key, locale, bundleName, replacements)
@@ -78,4 +82,30 @@ public open class EventContext<T : Event>(
         key: String,
         replacements: Array<Any?> = arrayOf()
     ): String = translate(key, eventHandler.extension.bundle, replacements)
+
+    /**
+     * Given a translation key and possible replacements,return the translation for the given locale in the
+     * extension's configured bundle, for the locale provided by the bot's configured locale resolvers.
+     */
+    public suspend fun translate(
+        key: String,
+        replacements: Map<String, Any?>
+    ): String = translate(key, eventHandler.extension.bundle, replacements)
+
+    private suspend fun resolveLocale(): Locale? {
+        val eventObj = event as Event
+
+        val guild = guildFor(eventObj)
+        val channel = channelFor(eventObj)
+        val user = userFor(eventObj)
+
+        for (resolver in eventHandler.extension.bot.settings.i18nBuilder.localeResolvers) {
+            val result = resolver(guild, channel, user, interactionFor(eventObj))
+
+            if (result != null) {
+                return result
+            }
+        }
+        return null
+    }
 }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventContext.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventContext.kt
@@ -75,7 +75,7 @@ public open class EventContext<T : Event>(
     }
 
     /**
-     * Given a translation key and possible replacements,return the translation for the given locale in the
+     * Given a translation key and possible replacements, return the translation for the given locale in the
      * extension's configured bundle, for the locale provided by the bot's configured locale resolvers.
      */
     public suspend fun translate(
@@ -84,7 +84,7 @@ public open class EventContext<T : Event>(
     ): String = translate(key, eventHandler.extension.bundle, replacements)
 
     /**
-     * Given a translation key and possible replacements,return the translation for the given locale in the
+     * Given a translation key and possible replacements, return the translation for the given locale in the
      * extension's configured bundle, for the locale provided by the bot's configured locale resolvers.
      */
     public suspend fun translate(
@@ -106,6 +106,7 @@ public open class EventContext<T : Event>(
                 return result
             }
         }
+
         return null
     }
 }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventHandler.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventHandler.kt
@@ -284,7 +284,7 @@ public open class EventHandler<T : Event>(
     }
 
     /**
-     * Given a translation key and possible replacements,return the translation for the given locale in the
+     * Given a translation key and possible replacements, return the translation for the given locale in the
      * extension's configured bundle, for the locale provided by the bot's configured locale resolvers.
      */
     public suspend fun Event.translate(key: String, replacements: Array<Any?> = arrayOf()): String = translate(
@@ -294,7 +294,7 @@ public open class EventHandler<T : Event>(
     )
 
     /**
-     * Given a translation key and possible replacements,return the translation for the given locale in the
+     * Given a translation key and possible replacements, return the translation for the given locale in the
      * extension's configured bundle, for the locale provided by the bot's configured locale resolvers.
      */
     public suspend fun Event.translate(key: String, replacements: Map<String, Any?>): String = translate(

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventHandler.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventHandler.kt
@@ -270,10 +270,34 @@ public open class EventHandler<T : Event>(
     }
 
     /**
+     * Given a translation key and bundle name, return the translation for the locale provided by the bot's configured
+     * locale resolvers.
+     */
+    public suspend fun Event.translate(
+        key: String,
+        bundleName: String?,
+        replacements: Map<String, Any?>
+    ): String {
+        val locale = getLocale()
+
+        return translationsProvider.translate(key, locale, bundleName, replacements)
+    }
+
+    /**
      * Given a translation key and possible replacements,return the translation for the given locale in the
      * extension's configured bundle, for the locale provided by the bot's configured locale resolvers.
      */
     public suspend fun Event.translate(key: String, replacements: Array<Any?> = arrayOf()): String = translate(
+        key,
+        extension.bundle,
+        replacements
+    )
+
+    /**
+     * Given a translation key and possible replacements,return the translation for the given locale in the
+     * extension's configured bundle, for the locale provided by the bot's configured locale resolvers.
+     */
+    public suspend fun Event.translate(key: String, replacements: Map<String, Any?>): String = translate(
         key,
         extension.bundle,
         replacements

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/i18n/ResourceBundleTranslations.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/i18n/ResourceBundleTranslations.kt
@@ -59,7 +59,7 @@ public open class ResourceBundleTranslations(
     ): ResourceBundle = ResourceBundle.getBundle(bundle, locale, control)
 
     /**
-     * Retrieves a pair of the [ResourceBundle] and the overide resource bundle for [bundleName] in locale.
+     * Retrieves a pair of the [ResourceBundle] and the override resource bundle for [bundleName] in locale.
      */
     @Throws(MissingResourceException::class)
     protected open fun getBundles(locale: Locale, bundleName: String?): Pair<ResourceBundle, ResourceBundle?> {
@@ -120,7 +120,12 @@ public open class ResourceBundleTranslations(
         return result
     }
 
-    private fun getTranslatedString(key: String, locale: Locale, bundleName: String?): String {
+    /**
+     * Retrieve a translated string from a [key] in a given [bundleName].
+     *
+     * The string's parameters are not replaced.
+     */
+    protected fun getTranslatedString(key: String, locale: Locale, bundleName: String?): String {
         var string = try {
             get(key, locale, bundleName)
         } catch (e: MissingResourceException) {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/i18n/ResourceBundleTranslations.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/i18n/ResourceBundleTranslations.kt
@@ -120,7 +120,7 @@ public open class ResourceBundleTranslations(
         return result
     }
 
-    override fun translate(key: String, locale: Locale, bundleName: String?, replacements: Array<Any?>): String {
+    private fun getTranslatedString(key: String, locale: Locale, bundleName: String?): String {
         var string = try {
             get(key, locale, bundleName)
         } catch (e: MissingResourceException) {
@@ -134,10 +134,7 @@ public open class ResourceBundleTranslations(
 
                 string = get(key, locale, KORDEX_KEY)
             }
-
-            val formatter = MessageFormat(string, locale)
-
-            formatter.format(replacements)
+            string
         } catch (e: MissingResourceException) {
             logger.trace {
                 if (bundleName == null) {
@@ -149,6 +146,22 @@ public open class ResourceBundleTranslations(
 
             key
         }
+    }
+
+    override fun translate(key: String, locale: Locale, bundleName: String?, replacements: Array<Any?>): String {
+        val string = getTranslatedString(key, locale, bundleName)
+
+        val formatter = MessageFormat(string, locale)
+
+        return formatter.format(replacements)
+    }
+
+    override fun translate(key: String, locale: Locale, bundleName: String?, replacements: Map<String, Any?>): String {
+        val string = getTranslatedString(key, locale, bundleName)
+
+        val formatter = MessageFormat(string, locale)
+
+        return formatter.format(replacements)
     }
 
     private fun ResourceBundle.getStringOrNull(key: String): String? {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/i18n/TranslationsProvider.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/i18n/TranslationsProvider.kt
@@ -115,4 +115,44 @@ public abstract class TranslationsProvider(
         bundleName: String? = null,
         replacements: List<Any?>
     ): String = translate(key, language, country, bundleName, replacements.toTypedArray())
+
+    /** Get a formatted translation using the provided arguments. **/
+    public open fun translate(
+        key: String,
+        bundleName: String? = null,
+        replacements: Map<String, Any?>
+    ): String = translate(key, defaultLocale, bundleName, replacements)
+
+    /** Get a formatted translation using the provided arguments. **/
+    public open fun translate(
+        key: String,
+        bundleName: String? = null,
+        locale: Locale,
+        replacements: Map<String, Any?>
+    ): String = translate(key, locale, bundleName, replacements)
+
+    /** Get a formatted translation using the provided arguments. **/
+    public abstract fun translate(
+        key: String,
+        locale: Locale,
+        bundleName: String? = null,
+        replacements: Map<String, Any?>
+    ): String
+
+    /** Get a formatted translation using the provided arguments. **/
+    public open fun translate(
+        key: String,
+        language: String,
+        bundleName: String? = null,
+        replacements: Map<String, Any?>
+    ): String = translate(key, Locale(language), bundleName, replacements)
+
+    /** Get a formatted translation using the provided arguments. **/
+    public open fun translate(
+        key: String,
+        language: String,
+        country: String,
+        bundleName: String? = null,
+        replacements: Map<String, Any?>
+    ): String = translate(key, Locale(language, country), bundleName, replacements)
 }

--- a/test-bot/src/main/kotlin/com/kotlindiscord/kord/extensions/testbot/extensions/I18nTestExtension.kt
+++ b/test-bot/src/main/kotlin/com/kotlindiscord/kord/extensions/testbot/extensions/I18nTestExtension.kt
@@ -11,6 +11,7 @@ package com.kotlindiscord.kord.extensions.testbot.extensions
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.application.slash.group
 import com.kotlindiscord.kord.extensions.commands.application.slash.publicSubCommand
+import com.kotlindiscord.kord.extensions.commands.converters.impl.int
 import com.kotlindiscord.kord.extensions.commands.converters.impl.string
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
@@ -94,6 +95,23 @@ public class I18nTestExtension : Extension() {
                 }
             }
         }
+
+        publicSlashCommand(::I18nTestNamedArguments) {
+            name = "command.apple"
+            description = "command.apple"
+
+            action {
+                respond {
+                    content = translate(
+                        "command.apple.response",
+                        mapOf(
+                            "name" to arguments.name,
+                            "appleCount" to arguments.count
+                        )
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -106,5 +124,17 @@ internal class I18nTestArguments : Arguments() {
                 listOf("Banana", "Apple", "Cherry").forEach { choice(it, it) }
             }
         }
+    }
+}
+
+internal class I18nTestNamedArguments : Arguments() {
+    val name by string {
+        name = "command.apple.argument.name"
+        description = "command.apple.argument.name"
+    }
+
+    val count by int {
+        name = "command.apple.argument.count"
+        description = "command.apple.argument.count"
     }
 }

--- a/test-bot/src/main/kotlin/com/kotlindiscord/kord/extensions/testbot/extensions/I18nTestExtension.kt
+++ b/test-bot/src/main/kotlin/com/kotlindiscord/kord/extensions/testbot/extensions/I18nTestExtension.kt
@@ -127,6 +127,7 @@ public class I18nTestExtension : Extension() {
             }
 
             action {
+                // This command is expected to always fail, in order to test checks.
                 respond {
                     content = "It is impossible to get here."
                 }
@@ -138,6 +139,7 @@ public class I18nTestExtension : Extension() {
             description = "Command with arguments that always fail validations."
 
             action {
+                // This command is expected to always fail, in order to test argument validations.
                 respond {
                     content = "It is impossible to get here."
                 }
@@ -165,7 +167,7 @@ public class I18nTestExtension : Extension() {
                 // Translate with a different bundle, and positional parameters
                 add(translate("check.positionalParameters", "custom", arrayOf(user.mention, user.id)))
                 // Translate with default bundle, named parameters
-                add(translate("check.namedParameters", mapOf("user" to user.mention, "id" to user.id)))
+                add(translate("check.namedParameters", replacements = mapOf("user" to user.mention, "id" to user.id)))
                 // Translate with a different bundle, and named parameters
                 add(translate("check.namedParameters", "custom", mapOf("user" to user.mention, "id" to user.id)))
             }.joinToString("\n")

--- a/test-bot/src/main/kotlin/com/kotlindiscord/kord/extensions/testbot/extensions/I18nTestExtension.kt
+++ b/test-bot/src/main/kotlin/com/kotlindiscord/kord/extensions/testbot/extensions/I18nTestExtension.kt
@@ -8,15 +8,19 @@
 
 package com.kotlindiscord.kord.extensions.testbot.extensions
 
+import com.kotlindiscord.kord.extensions.checks.types.CheckContextWithCache
+import com.kotlindiscord.kord.extensions.checks.userFor
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.application.slash.group
 import com.kotlindiscord.kord.extensions.commands.application.slash.publicSubCommand
 import com.kotlindiscord.kord.extensions.commands.converters.impl.int
 import com.kotlindiscord.kord.extensions.commands.converters.impl.string
 import com.kotlindiscord.kord.extensions.extensions.Extension
+import com.kotlindiscord.kord.extensions.extensions.ephemeralSlashCommand
 import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
 import com.kotlindiscord.kord.extensions.types.respond
 import dev.kord.core.behavior.interaction.suggestString
+import dev.kord.core.event.interaction.ChatInputCommandInteractionCreateEvent
 
 public class I18nTestExtension : Extension() {
     override val name: String = "test-i18n"
@@ -104,12 +108,92 @@ public class I18nTestExtension : Extension() {
                 respond {
                     content = translate(
                         "command.apple.response",
+
                         mapOf(
                             "name" to arguments.name,
                             "appleCount" to arguments.count
                         )
                     )
                 }
+            }
+        }
+
+        ephemeralSlashCommand {
+            name = "test-translated-checks"
+            description = "Command that always fails, to check CheckContext translations."
+
+            check {
+                translatedChecks()
+            }
+
+            action {
+                respond {
+                    content = "It is impossible to get here."
+                }
+            }
+        }
+
+        ephemeralSlashCommand(::I18nTestValidations) {
+            name = "test-translated-validations"
+            description = "Command with arguments that always fail validations."
+
+            action {
+                respond {
+                    content = "It is impossible to get here."
+                }
+            }
+        }
+    }
+
+    private suspend fun CheckContextWithCache<ChatInputCommandInteractionCreateEvent>.translatedChecks() {
+        val user = userFor(event)
+        this.defaultBundle = bundle
+
+        if (user == null) {
+            fail("Could not get user.")
+            return
+        }
+
+        fail(
+            buildList {
+                // Translate, with default bundle
+                add(translate("check.simple"))
+                // Translate with a different bundle
+                add(translate("check.simple", "custom"))
+                // Translate with default bundle, and positional parameters
+                add(translate("check.positionalParameters", arrayOf(user.mention, user.id)))
+                // Translate with a different bundle, and positional parameters
+                add(translate("check.positionalParameters", "custom", arrayOf(user.mention, user.id)))
+                // Translate with default bundle, named parameters
+                add(translate("check.namedParameters", mapOf("user" to user.mention, "id" to user.id)))
+                // Translate with a different bundle, and named parameters
+                add(translate("check.namedParameters", "custom", mapOf("user" to user.mention, "id" to user.id)))
+            }.joinToString("\n")
+        )
+    }
+
+    private inner class I18nTestValidations : Arguments() {
+        val name by string {
+            name = "name"
+            description = "Will always fail to validate."
+            validate {
+                defaultBundle = bundle
+                fail(
+                    buildList {
+                        // Translate, with default bundle
+                        add(translate("validation.simple"))
+                        // Translate with a different bundle
+                        add(translate("validation.simple", "custom"))
+                        // Translate with default bundle, and positional parameters
+                        add(translate("validation.positionalParameters", arrayOf(value)))
+                        // Translate with a different bundle, and positional parameters
+                        add(translate("validation.positionalParameters", "custom", arrayOf(value)))
+                        // Translate with default bundle, named parameters
+                        add(translate("validation.namedParameters", mapOf("value" to value)))
+                        // Translate with a different bundle, and named parameters
+                        add(translate("validation.namedParameters", "custom", mapOf("value" to value)))
+                    }.joinToString("\n")
+                )
             }
         }
     }

--- a/test-bot/src/main/resources/translations/custom/strings.properties
+++ b/test-bot/src/main/resources/translations/custom/strings.properties
@@ -1,0 +1,6 @@
+check.simple=This is a check from a different bundle.
+check.positionalParameters={0} (ID: {1}) can never use this command, even from a different strings bundle.
+check.namedParameters={user} (ID: {id}) can never use this command, even from a different strings bundle.
+validation.simple=This is a validation from another bundle.
+validation.positionalParameters={0} is not valid (from a different bundle).
+validation.namedParameters={value} is not valid (from a different bundle).

--- a/test-bot/src/main/resources/translations/custom/strings.properties
+++ b/test-bot/src/main/resources/translations/custom/strings.properties
@@ -1,3 +1,9 @@
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+
 check.simple=This is a check from a different bundle.
 check.positionalParameters={0} (ID: {1}) can never use this command, even from a different strings bundle.
 check.namedParameters={user} (ID: {id}) can never use this command, even from a different strings bundle.

--- a/test-bot/src/main/resources/translations/test/strings.properties
+++ b/test-bot/src/main/resources/translations/test/strings.properties
@@ -10,3 +10,7 @@ command.banana-sub=banana-sub
 command.banana-group=banana-group
 command.fruit=fruit
 command.fruit.response=my favorite fruit is {0}
+command.apple=apple
+command.apple.response=Hello my name is **{name}** and I have **{appleCount, number}** {appleCount, plural, =1{apple} other {apples}}.
+command.apple.argument.name=name
+command.apple.argument.count=apple_count

--- a/test-bot/src/main/resources/translations/test/strings.properties
+++ b/test-bot/src/main/resources/translations/test/strings.properties
@@ -14,3 +14,9 @@ command.apple=apple
 command.apple.response=Hello my name is **{name}** and I have **{appleCount, number}** {appleCount, plural, =1{apple} other {apples}}.
 command.apple.argument.name=name
 command.apple.argument.count=apple_count
+check.simple=Command check did not pass.
+check.positionalParameters={0} (ID: {1}) can never use this command.
+check.namedParameters={user} (ID: {id}) can never use this command.
+validation.simple=Argument validation did not pass.
+validation.positionalParameters={0} is not valid.
+validation.namedParameters={value} is not valid.


### PR DESCRIPTION
This adds overloads to all translate functions to also accept a mapping of argument names to argument values:

**Example**:
```properties
command.apple.response=Hello my name is **{name}** and I have **{appleCount, number}** {appleCount, plural, =1{apple} other {apples}}.
```

```kt
translate("command.apple.response", mapOf("name" to "Allan", "appleCount" to 1))
> "Hello my name is **Allan** and I have **1** apple."
```

In some cases I extracted some code out current `translate` methods to avoid repeating it for the overload for named arguments.