### PR TITLE
Update phishing and pluralkit extension to use nullable functions and…

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/kord-extensions/kord-extensions.kord-extensions.iml" filepath="$PROJECT_DIR$/.idea/modules/kord-extensions/kord-extensions.kord-extensions.iml" />
-    </modules>
-  </component>
-</project>

--- a/extra-modules/extra-phishing/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/phishing/PhishingExtension.kt
+++ b/extra-modules/extra-phishing/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/phishing/PhishingExtension.kt
@@ -282,11 +282,7 @@ class PhishingExtension(private val settings: ExtPhishingBuilder) : Extension() 
         val domains: MutableSet<String> = mutableSetOf()
 
         for (match in settings.urlRegex.findAll(content)) {
-            val found = match.groups[1]?.value?.trim('/')
-
-            if (found == null) {
-                continue
-            }
+            val found = match.groups[1]?.value?.trim('/') ?: continue
 
             var domain = found
 
@@ -294,12 +290,12 @@ class PhishingExtension(private val settings: ExtPhishingBuilder) : Extension() 
                 domain = domain
                     .split("/", limit = 2)
                     .firstOrNull()
-                    ?.lowercase()
+                    ?.lowercase() ?: continue
             }
 
-            domain = domain?.filter { it.isLetterOrDigit() || it in "-+&@#%?=~_|!:,.;" }
+            domain = domain.filter { it.isLetterOrDigit() || it in "-+&@#%?=~_|!:,.;" }
 
-            if (domain in domainCache && domain != null) {
+            if (domain in domainCache) {
                 domains.add(domain)
             } else {
                 val result = followRedirects(match.value)
@@ -341,7 +337,7 @@ class PhishingExtension(private val settings: ExtPhishingBuilder) : Extension() 
 
             return url
         } catch (e: Exception) {
-            logger.debug(e) { e.message }
+            logger.warn(e) { url }
 
             return url
         }

--- a/extra-modules/extra-phishing/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/phishing/PhishingExtension.kt
+++ b/extra-modules/extra-phishing/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/phishing/PhishingExtension.kt
@@ -77,7 +77,7 @@ class PhishingExtension(private val settings: ExtPhishingBuilder) : Extension() 
             }
 
             action {
-                handleMessage(event.message)
+                handleMessage(event.message.asMessageOrNull())
             }
         }
 
@@ -92,7 +92,7 @@ class PhishingExtension(private val settings: ExtPhishingBuilder) : Extension() 
             }
 
             action {
-                handleMessage(event.message.asMessage())
+                handleMessage(event.message.asMessageOrNull())
             }
         }
 
@@ -140,7 +140,11 @@ class PhishingExtension(private val settings: ExtPhishingBuilder) : Extension() 
         }
     }
 
-    internal suspend fun handleMessage(message: Message) {
+    internal suspend fun handleMessage(message: Message?) {
+        if (message == null) {
+            return
+        }
+
         val matches = parseDomains(message.content)
 
         if (matches.isNotEmpty()) {
@@ -175,7 +179,7 @@ class PhishingExtension(private val settings: ExtPhishingBuilder) : Extension() 
                                 inline = true
 
                                 name = "Server"
-                                value = message.getGuild().name
+                                value = message.getGuildOrNull()?.name ?: "Unable to get guild"
                             }
                         }
                     }
@@ -278,19 +282,24 @@ class PhishingExtension(private val settings: ExtPhishingBuilder) : Extension() 
         val domains: MutableSet<String> = mutableSetOf()
 
         for (match in settings.urlRegex.findAll(content)) {
-            val found = match.groups[1]!!.value.trim('/')
+            val found = match.groups[1]?.value?.trim('/')
+
+            if (found == null) {
+                continue
+            }
+
             var domain = found
 
             if ("/" in domain) {
                 domain = domain
                     .split("/", limit = 2)
-                    .first()
-                    .lowercase()
+                    .firstOrNull()
+                    ?.lowercase()
             }
 
-            domain = domain.filter { it.isLetterOrDigit() || it in "-+&@#%?=~_|!:,.;" }
+            domain = domain?.filter { it.isLetterOrDigit() || it in "-+&@#%?=~_|!:,.;" }
 
-            if (domain in domainCache) {
+            if (domain in domainCache && domain != null) {
                 domains.add(domain)
             } else {
                 val result = followRedirects(match.value)
@@ -300,8 +309,8 @@ class PhishingExtension(private val settings: ExtPhishingBuilder) : Extension() 
                     ?.first()
                     ?.lowercase()
 
-                if (result in domainCache) {
-                    domains.add(result!!)
+                if (result in domainCache && result != null) {
+                    domains.add(result)
                 }
             }
         }
@@ -311,7 +320,7 @@ class PhishingExtension(private val settings: ExtPhishingBuilder) : Extension() 
         return domains
     }
 
-    @Suppress("MagicNumber")  // HTTP status codes
+    @Suppress("MagicNumber", "TooGenericExceptionCaught")  // HTTP status codes
     internal suspend fun followRedirects(url: String, count: Int = 0): String? {
         if (count >= MAX_REDIRECTS) {
             logger.warn { "Maximum redirect count reached for URL: $url" }
@@ -331,12 +340,8 @@ class PhishingExtension(private val settings: ExtPhishingBuilder) : Extension() 
             }
 
             return url
-        } catch (e: HttpRequestTimeoutException) {
-            logger.warn { "$url -> Request timeout has expired." }
-
-            return url
-        } catch (e: URLParserException) {
-            logger.debug { "$url -> Failed to parse url" }
+        } catch (e: Exception) {
+            logger.debug(e) { e.message }
 
             return url
         }
@@ -350,7 +355,6 @@ class PhishingExtension(private val settings: ExtPhishingBuilder) : Extension() 
 
             return followRedirects(newUrl, count + 1)
         } else {
-            @Suppress("TooGenericExceptionCaught")
             val soup = try {
                 Jsoup.connect(url).get()
             } catch (e: Exception) {

--- a/extra-modules/extra-pluralkit/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/pluralkit/PKExtension.kt
+++ b/extra-modules/extra-pluralkit/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/pluralkit/PKExtension.kt
@@ -37,7 +37,6 @@ import com.kotlindiscord.kord.extensions.utils.scheduling.Task
 import dev.kord.common.entity.Permission
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.behavior.GuildBehavior
-import dev.kord.core.behavior.channel.asChannelOf
 import dev.kord.core.behavior.channel.asChannelOfOrNull
 import dev.kord.core.entity.Message
 import dev.kord.core.entity.channel.GuildChannel
@@ -149,15 +148,21 @@ class PKExtension : Extension() {
                     return@action
                 }
 
-                val channel = topChannelFor(event)!!.asChannelOf<TopGuildMessageChannel>()
+                val channel = try {
+                    topChannelFor(event)?.asChannelOfOrNull<TopGuildMessageChannel>()
+                } catch (e: ClassCastException) {
+                    logger.warn(e) { "Failed to cast channel to TopGuildMessageChannel" }
+
+                    null
+                }
 
                 val webhook = try {
                     channel
-                        .asChannelOf<TopGuildMessageChannel>()
-                        .webhooks
-                        .firstOrNull { it.id == webhookId }
+                        ?.asChannelOfOrNull<TopGuildMessageChannel>()
+                        ?.webhooks
+                        ?.firstOrNull { it.id == webhookId }
                 } catch (e: KtorRequestException) {
-                    logger.warn(e) { "Failed to retrieve webhooks for channel: ${channel.id}" }
+                    logger.warn(e) { "Failed to retrieve webhooks for channel: ${channel?.id}" }
 
                     null
                 }
@@ -230,15 +235,21 @@ class PKExtension : Extension() {
                     return@action
                 }
 
-                val channel = topChannelFor(event)!!.asChannelOf<TopGuildMessageChannel>()
+                val channel = try {
+                    topChannelFor(event)?.asChannelOfOrNull<TopGuildMessageChannel>()
+                } catch (e: ClassCastException) {
+                    logger.warn(e) { "Failed to cast channel to TopGuildMessageChannel" }
+
+                    null
+                }
 
                 val webhook = try {
                     channel
-                        .asChannelOf<TopGuildMessageChannel>()
-                        .webhooks
-                        .firstOrNull { it.id == webhookId }
+                        ?.asChannelOfOrNull<TopGuildMessageChannel>()
+                        ?.webhooks
+                        ?.firstOrNull { it.id == webhookId }
                 } catch (e: KtorRequestException) {
-                    logger.warn(e) { "Failed to retrieve webhooks for channel: ${channel.id}" }
+                    logger.warn(e) { "Failed to retrieve webhooks for channel: ${channel?.id}" }
 
                     null
                 }
@@ -266,7 +277,7 @@ class PKExtension : Extension() {
 
         event<MessageUpdateEvent> {
             action {
-                val guild = event.channel.asChannelOfOrNull<GuildChannel>()?.getGuild()
+                val guild = event.channel.asChannelOfOrNull<GuildChannel>()?.getGuildOrNull()
 
                 if (guild == null) {
                     kord.launch {
@@ -297,15 +308,21 @@ class PKExtension : Extension() {
                     return@action
                 }
 
-                val channel = topChannelFor(event)!!.asChannelOf<TopGuildMessageChannel>()
+                val channel = try {
+                    topChannelFor(event)?.asChannelOfOrNull<TopGuildMessageChannel>()
+                } catch (e: ClassCastException) {
+                    logger.warn(e) { "Failed to cast channel to TopGuildMessageChannel" }
+
+                    null
+                }
 
                 val webhook = try {
                     channel
-                        .asChannelOf<TopGuildMessageChannel>()
-                        .webhooks
-                        .firstOrNull { it.id == webhookId }
+                        ?.asChannelOfOrNull<TopGuildMessageChannel>()
+                        ?.webhooks
+                        ?.firstOrNull { it.id == webhookId }
                 } catch (e: KtorRequestException) {
-                    logger.warn(e) { "Failed to retrieve webhooks for channel: ${channel.id}" }
+                    logger.warn(e) { "Failed to retrieve webhooks for channel: ${channel?.id}" }
 
                     null
                 }

--- a/extra-modules/extra-pluralkit/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/pluralkit/PKExtension.kt
+++ b/extra-modules/extra-pluralkit/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/pluralkit/PKExtension.kt
@@ -148,6 +148,7 @@ class PKExtension : Extension() {
                     return@action
                 }
 
+                // This is to work around Kord's lack of support for forum channels. This can go once they're supported.
                 val channel = try {
                     topChannelFor(event)?.asChannelOfOrNull<TopGuildMessageChannel>()
                 } catch (e: ClassCastException) {
@@ -235,6 +236,7 @@ class PKExtension : Extension() {
                     return@action
                 }
 
+                // This is to work around Kord's lack of support for forum channels. This can go once they're supported.
                 val channel = try {
                     topChannelFor(event)?.asChannelOfOrNull<TopGuildMessageChannel>()
                 } catch (e: ClassCastException) {
@@ -308,6 +310,7 @@ class PKExtension : Extension() {
                     return@action
                 }
 
+                // This is to work around Kord's lack of support for forum channels. This can go once they're supported.
                 val channel = try {
                     topChannelFor(event)?.asChannelOfOrNull<TopGuildMessageChannel>()
                 } catch (e: ClassCastException) {


### PR DESCRIPTION
… catch some more exceptions.

Previously, the phishing extension would relentlessly send exceptions for being unable to read URLs for various reasons, this is extremely frustrating since it's out of the users control. I've switch this to catch all exceptions, and log them at warn level instead, so they're still visible.

The PluralKit extension attempts to get channels using `asChannelOf` currently, resulting in class cast exceptions and null pointer exceptions. I have moves over to using `asChannelOfOrNull` to avoid the NPEs and surrounded initial attempts at using this function with a try/catch for `ClassCastExceptions`