### PR TITLE
Address Deprecations and unused suppressions/optins

### DIFF
--- a/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/utils/McpNamespaceReplacement.kt
+++ b/extra-modules/extra-mappings/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/mappings/utils/McpNamespaceReplacement.kt
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-@file:Suppress("BlockingMethodInNonBlockingContext")
-
 package com.kotlindiscord.kord.extensions.modules.extra.mappings.utils
 
 import kotlinx.serialization.builtins.MapSerializer

--- a/extra-modules/extra-pluralkit/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/pluralkit/PKExtension.kt
+++ b/extra-modules/extra-pluralkit/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/pluralkit/PKExtension.kt
@@ -111,7 +111,7 @@ class PKExtension : Extension() {
 
         event<MessageCreateEvent> {
             action {
-                val guild = event.getGuild()
+                val guild = event.getGuildOrNull()
 
                 if (guild == null) {
                     kord.launch {
@@ -195,7 +195,7 @@ class PKExtension : Extension() {
 
         event<MessageDeleteEvent> {
             action {
-                val guild = event.getGuild()
+                val guild = event.getGuildOrNull()
 
                 if (guild == null) {
                     kord.launch {

--- a/extra-modules/extra-pluralkit/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/pluralkit/events/PKMessageCreateEvent.kt
+++ b/extra-modules/extra-pluralkit/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/pluralkit/events/PKMessageCreateEvent.kt
@@ -144,7 +144,7 @@ class UnProxiedMessageCreateEvent(
 }
 
 internal suspend fun MessageCreateEvent.proxied(p: PKMessage, referencedMessage: Message?): ProxiedMessageCreateEvent {
-    val member = getGuild()!!.getMemberOrNull(p.sender)!!
+    val member = getGuildOrNull()!!.getMemberOrNull(p.sender)!!
 
     return ProxiedMessageCreateEvent(
         this,

--- a/extra-modules/extra-pluralkit/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/pluralkit/events/PKMessageDeleteEvent.kt
+++ b/extra-modules/extra-pluralkit/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/extra/pluralkit/events/PKMessageDeleteEvent.kt
@@ -163,7 +163,7 @@ class UnProxiedMessageDeleteEvent(
 }
 
 internal suspend fun MessageDeleteEvent.proxied(p: PKMessage, referencedMessage: Message?): ProxiedMessageDeleteEvent {
-    val member = getGuild()!!.getMemberOrNull(p.sender)!!
+    val member = getGuildOrNull()!!.getMemberOrNull(p.sender)!!
 
     return ProxiedMessageDeleteEvent(
         this,

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/ChannelChecks.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/ChannelChecks.kt
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-@file:Suppress("RedundantSuspendModifier")
-
 package com.kotlindiscord.kord.extensions.checks
 
 import com.kotlindiscord.kord.extensions.checks.types.CheckContext

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/ChannelTypeChecks.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/ChannelTypeChecks.kt
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-@file:Suppress("RedundantSuspendModifier")
-
 package com.kotlindiscord.kord.extensions.checks
 
 import com.kotlindiscord.kord.extensions.checks.types.CheckContext

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/CheckUtils.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/CheckUtils.kt
@@ -315,7 +315,7 @@ public suspend fun memberFor(event: Event): MemberBehavior? {
         is ReactionAddEvent -> event.userAsMember
         is ReactionRemoveEvent -> event.userAsMember
         is TypingStartEvent -> if (event.guildId != null) {
-            event.getGuild()!!.getMemberOrNull(event.userId)
+            event.getGuildOrNull()!!.getMemberOrNull(event.userId)
         } else {
             null
         }

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/GuildChecks.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/GuildChecks.kt
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-@file:Suppress("RedundantSuspendModifier")
-
 package com.kotlindiscord.kord.extensions.checks
 
 import com.kotlindiscord.kord.extensions.checks.types.CheckContext

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/MemberChecks.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/MemberChecks.kt
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-@file:Suppress("RedundantSuspendModifier")
-
 package com.kotlindiscord.kord.extensions.checks
 
 import com.kotlindiscord.kord.extensions.checks.types.CheckContext

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/NSFWChecks.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/NSFWChecks.kt
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-@file:Suppress("RedundantSuspendModifier", "StringLiteralDuplication")
+@file:Suppress("StringLiteralDuplication")
 
 package com.kotlindiscord.kord.extensions.checks
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/RoleChecks.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/RoleChecks.kt
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-@file:Suppress("RedundantSuspendModifier", "StringLiteralDuplication")
+@file:Suppress("StringLiteralDuplication")
 
 package com.kotlindiscord.kord.extensions.checks
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/TopChannelChecks.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/checks/TopChannelChecks.kt
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-@file:Suppress("RedundantSuspendModifier")
-
 package com.kotlindiscord.kord.extensions.checks
 
 import com.kotlindiscord.kord.extensions.checks.types.CheckContext

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/StorageAwareApplicationCommandRegistry.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/StorageAwareApplicationCommandRegistry.kt
@@ -4,13 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-@file:Suppress(
-    "UNCHECKED_CAST"
-)
-@file:OptIn(
-    ExperimentalCoroutinesApi::class
-)
-
 package com.kotlindiscord.kord.extensions.commands.application
 
 import com.kotlindiscord.kord.extensions.commands.application.message.MessageCommand
@@ -23,7 +16,6 @@ import dev.kord.core.event.interaction.AutoCompleteInteractionCreateEvent
 import dev.kord.core.event.interaction.ChatInputCommandInteractionCreateEvent
 import dev.kord.core.event.interaction.MessageCommandInteractionCreateEvent
 import dev.kord.core.event.interaction.UserCommandInteractionCreateEvent
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.toList
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/SlashCommandParser.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/SlashCommandParser.kt
@@ -4,7 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-@file:OptIn(KordPreview::class)
 @file:Suppress(
     "StringLiteralDuplication" // Needs cleaning up with polymorphism later anyway
 )
@@ -17,7 +16,6 @@ import com.kotlindiscord.kord.extensions.commands.Argument
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.converters.*
 import com.kotlindiscord.kord.extensions.commands.getDefaultTranslatedDisplayName
-import dev.kord.common.annotation.KordPreview
 import dev.kord.core.entity.interaction.OptionValue
 import dev.kord.core.entity.interaction.StringOptionValue
 import mu.KotlinLogging

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/sentry/_Utils.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/sentry/_Utils.kt
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-@file:Suppress("TooGenericExceptionCaught", "unused")
+@file:Suppress("TooGenericExceptionCaught")
 
 package com.kotlindiscord.kord.extensions.sentry
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_NsfwLevels.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_NsfwLevels.kt
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-@file:Suppress("unused")
-
 package com.kotlindiscord.kord.extensions.utils
 
 import com.kotlindiscord.kord.extensions.commands.CommandContext

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Permissions.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Permissions.kt
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-@file:Suppress("unused")
-
 package com.kotlindiscord.kord.extensions.utils
 
 import com.kotlindiscord.kord.extensions.commands.CommandContext

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Translation.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Translation.kt
@@ -27,7 +27,7 @@ public suspend fun MessageCreateEvent.getLocale(): Locale {
     var result = bot.settings.i18nBuilder.defaultLocale
 
     for (resolver in bot.settings.i18nBuilder.localeResolvers) {
-        val resolved = resolver(getGuild(), message.channel, message.author, null)
+        val resolved = resolver(getGuildOrNull(), message.channel, message.author, null)
 
         if (resolved != null) {
             result = resolved

--- a/modules/java-time/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/java/J8DurationCoalescingConverter.kt
+++ b/modules/java-time/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/java/J8DurationCoalescingConverter.kt
@@ -4,13 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-@file:OptIn(
-    KordPreview::class,
-    ConverterToDefaulting::class,
-    ConverterToMulti::class,
-    ConverterToOptional::class
-)
-
 package com.kotlindiscord.kord.extensions.modules.time.java
 
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
@@ -25,7 +18,6 @@ import com.kotlindiscord.kord.extensions.parser.StringParser
 import com.kotlindiscord.kord.extensions.parser.tokens.PositionalArgumentToken
 import com.kotlindiscord.kord.extensions.parsers.DurationParserException
 import com.kotlindiscord.kord.extensions.parsers.InvalidTimeUnitException
-import dev.kord.common.annotation.KordPreview
 import dev.kord.core.entity.interaction.OptionValue
 import dev.kord.core.entity.interaction.StringOptionValue
 import dev.kord.rest.builder.interaction.OptionsBuilder

--- a/modules/java-time/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/java/J8DurationConverter.kt
+++ b/modules/java-time/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/java/J8DurationConverter.kt
@@ -4,13 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-@file:OptIn(
-    KordPreview::class,
-    ConverterToDefaulting::class,
-    ConverterToMulti::class,
-    ConverterToOptional::class
-)
-
 package com.kotlindiscord.kord.extensions.modules.time.java
 
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
@@ -23,7 +16,6 @@ import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converte
 import com.kotlindiscord.kord.extensions.parser.StringParser
 import com.kotlindiscord.kord.extensions.parsers.DurationParserException
 import com.kotlindiscord.kord.extensions.parsers.InvalidTimeUnitException
-import dev.kord.common.annotation.KordPreview
 import dev.kord.core.entity.interaction.OptionValue
 import dev.kord.core.entity.interaction.StringOptionValue
 import dev.kord.rest.builder.interaction.OptionsBuilder
@@ -50,7 +42,6 @@ import java.time.LocalDateTime
         "public var positiveOnly: Boolean = true",
     ],
 )
-@OptIn(KordPreview::class)
 public class J8DurationConverter(
     public val longHelp: Boolean = true,
     public val positiveOnly: Boolean = true,

--- a/modules/java-time/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/TestExtension.kt
+++ b/modules/java-time/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/TestExtension.kt
@@ -12,10 +12,8 @@ import com.kotlindiscord.kord.extensions.extensions.chatCommand
 import com.kotlindiscord.kord.extensions.modules.time.java.coalescingJ8Duration
 import com.kotlindiscord.kord.extensions.modules.time.java.toHuman
 import com.kotlindiscord.kord.extensions.utils.respond
-import dev.kord.common.annotation.KordPreview
 
 // They're IDs
-@OptIn(KordPreview::class)
 @Suppress("UnderscoresInNumericLiterals")
 class TestExtension : Extension() {
     override val name = "test"

--- a/modules/time4j/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/time4j/T4JDurationCoalescingConverter.kt
+++ b/modules/time4j/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/time4j/T4JDurationCoalescingConverter.kt
@@ -4,13 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-@file:OptIn(
-    KordPreview::class,
-    ConverterToDefaulting::class,
-    ConverterToMulti::class,
-    ConverterToOptional::class
-)
-
 package com.kotlindiscord.kord.extensions.modules.time.time4j
 
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
@@ -25,7 +18,6 @@ import com.kotlindiscord.kord.extensions.parser.StringParser
 import com.kotlindiscord.kord.extensions.parser.tokens.PositionalArgumentToken
 import com.kotlindiscord.kord.extensions.parsers.DurationParserException
 import com.kotlindiscord.kord.extensions.parsers.InvalidTimeUnitException
-import dev.kord.common.annotation.KordPreview
 import dev.kord.core.entity.interaction.OptionValue
 import dev.kord.core.entity.interaction.StringOptionValue
 import dev.kord.rest.builder.interaction.OptionsBuilder

--- a/modules/time4j/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/time4j/T4JDurationConverter.kt
+++ b/modules/time4j/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/time/time4j/T4JDurationConverter.kt
@@ -4,13 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-@file:OptIn(
-    KordPreview::class,
-    ConverterToDefaulting::class,
-    ConverterToMulti::class,
-    ConverterToOptional::class
-)
-
 package com.kotlindiscord.kord.extensions.modules.time.time4j
 
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
@@ -23,7 +16,6 @@ import com.kotlindiscord.kord.extensions.modules.annotations.converters.Converte
 import com.kotlindiscord.kord.extensions.parser.StringParser
 import com.kotlindiscord.kord.extensions.parsers.DurationParserException
 import com.kotlindiscord.kord.extensions.parsers.InvalidTimeUnitException
-import dev.kord.common.annotation.KordPreview
 import dev.kord.core.entity.interaction.OptionValue
 import dev.kord.core.entity.interaction.StringOptionValue
 import dev.kord.rest.builder.interaction.OptionsBuilder
@@ -42,7 +34,6 @@ import net.time4j.IsoUnit
  * @see t4jDurationList
  * @see parseT4JDuration
  */
-@OptIn(KordPreview::class)
 @Converter(
     names = ["t4JDuration"],
     types = [ConverterType.DEFAULTING, ConverterType.OPTIONAL, ConverterType.SINGLE],

--- a/modules/time4j/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/TestExtension.kt
+++ b/modules/time4j/src/test/kotlin/com/kotlindiscord/kord/extensions/test/bot/TestExtension.kt
@@ -12,10 +12,8 @@ import com.kotlindiscord.kord.extensions.extensions.chatCommand
 import com.kotlindiscord.kord.extensions.modules.time.time4j.coalescingT4JDuration
 import com.kotlindiscord.kord.extensions.modules.time.time4j.toHuman
 import com.kotlindiscord.kord.extensions.utils.respond
-import dev.kord.common.annotation.KordPreview
 
 // They're IDs
-@OptIn(KordPreview::class)
 @Suppress("UnderscoresInNumericLiterals")
 class TestExtension : Extension() {
     override val name = "test"

--- a/modules/unsafe/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/unsafe/converters/UnionConverter.kt
+++ b/modules/unsafe/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/unsafe/converters/UnionConverter.kt
@@ -5,9 +5,6 @@
  */
 
 @file:OptIn(
-    KordPreview::class,
-    ConverterToDefaulting::class,
-    ConverterToMulti::class,
     ConverterToOptional::class
 )
 @file:Suppress("StringLiteralDuplication")
@@ -23,7 +20,6 @@ import com.kotlindiscord.kord.extensions.i18n.DEFAULT_KORDEX_BUNDLE
 import com.kotlindiscord.kord.extensions.i18n.TranslationsProvider
 import com.kotlindiscord.kord.extensions.modules.unsafe.annotations.UnsafeAPI
 import com.kotlindiscord.kord.extensions.parser.StringParser
-import dev.kord.common.annotation.KordPreview
 import dev.kord.core.entity.interaction.OptionValue
 import dev.kord.rest.builder.interaction.OptionsBuilder
 import dev.kord.rest.builder.interaction.StringChoiceBuilder
@@ -37,7 +33,6 @@ private typealias GenericConverter = Converter<*, *, *, *>
  *
  * This converter does not support optional or defaulting converters.
  */
-@OptIn(KordPreview::class)
 @UnsafeAPI
 public class UnionConverter(
     private val converters: Collection<GenericConverter>,

--- a/test-bot/src/main/kotlin/com/kotlindiscord/kord/extensions/testbot/utils/LogLevel.kt
+++ b/test-bot/src/main/kotlin/com/kotlindiscord/kord/extensions/testbot/utils/LogLevel.kt
@@ -11,7 +11,6 @@ import com.kotlindiscord.kord.extensions.DISCORD_RED
 import com.kotlindiscord.kord.extensions.DISCORD_YELLOW
 import dev.kord.common.Color
 
-@Suppress("PropertyName")
 public sealed class LogLevel(
     public val name: String,
     public val color: Color?,


### PR DESCRIPTION
Addresses the deprecations of `getGuild` for `getGuildOrNull` methods and removes suppressions and OptIn annotations that where unused