### PR TITLE
User.dm should catch JSON error code 50007

### DIFF
--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Users.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/utils/_Users.kt
@@ -12,6 +12,7 @@ import dev.kord.core.entity.Message
 import dev.kord.core.entity.Role
 import dev.kord.core.entity.User
 import dev.kord.rest.builder.message.create.MessageCreateBuilder
+import dev.kord.rest.json.JsonErrorCode
 import dev.kord.rest.request.RestRequestException
 import io.ktor.http.*
 import kotlinx.datetime.Instant
@@ -60,7 +61,7 @@ public suspend inline fun User.dm(builder: MessageCreateBuilder.() -> Unit): Mes
     return try {
         this.getDmChannel().createMessage { builder() }
     } catch (e: RestRequestException) {
-        if (e.hasStatus(HttpStatusCode.Forbidden)) {
+        if (e.hasStatus(HttpStatusCode.BadRequest) && e.error?.code == JsonErrorCode.CannotSendMessagesToUser) {
             null
         } else {
             throw e


### PR DESCRIPTION
This endpoint is no longer responding with a Forbidden status code for cases where the user is unable to send DMs to the user.

Now a BadRequest code is received, so we need to check for the specific JSON error code so badly formatted message errors are not caught too.

I don't know if there could be other scenarios where Forbidden is used.