### PR TITLE
SlashCommand: Allow having groups and subcommands on the same level

### DIFF
--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/_Functions.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/_Functions.kt
@@ -32,10 +32,6 @@ public suspend fun SlashCommand<*, *, *>.group(name: String, body: suspend Slash
         error("Command groups may not be nested inside subcommands.")
     }
 
-    if (subCommands.isNotEmpty()) {
-        error("Commands may only contain subcommands or command groups, not both.")
-    }
-
     if (groups.size >= SUBCOMMAND_AND_GROUP_LIMIT) {
         error("Commands may only contain up to $SUBCOMMAND_AND_GROUP_LIMIT command groups.")
     }

--- a/test-bot/src/main/kotlin/com/kotlindiscord/kord/extensions/testbot/TestBot.kt
+++ b/test-bot/src/main/kotlin/com/kotlindiscord/kord/extensions/testbot/TestBot.kt
@@ -77,6 +77,7 @@ public suspend fun main() {
             add(::ModalTestExtension)
             add(::PaginatorTestExtension)
             add(::PKTestExtension)
+            add(::NestingTestExtension)
         }
 
         plugins {

--- a/test-bot/src/main/kotlin/com/kotlindiscord/kord/extensions/testbot/extensions/NestingTestExtension.kt
+++ b/test-bot/src/main/kotlin/com/kotlindiscord/kord/extensions/testbot/extensions/NestingTestExtension.kt
@@ -1,0 +1,50 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.kotlindiscord.kord.extensions.testbot.extensions
+
+import com.kotlindiscord.kord.extensions.commands.application.slash.group
+import com.kotlindiscord.kord.extensions.commands.application.slash.publicSubCommand
+import com.kotlindiscord.kord.extensions.extensions.Extension
+import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
+import com.kotlindiscord.kord.extensions.types.respond
+
+public class NestingTestExtension : Extension() {
+    override val name: String = "test-nesting"
+
+    override suspend fun setup() {
+        publicSlashCommand {
+            name = "root"
+            description = "Insert thoughtful proverb here"
+
+            group("group") {
+                description = "Insert required description here"
+
+                publicSubCommand {
+                    name = "subcommand"
+                    description = "...in a group!"
+
+                    action {
+                        respond {
+                            content = "Ah-ah-ah!"
+                        }
+                    }
+                }
+            }
+
+            publicSubCommand {
+                name = "subcommand"
+                description = "...NEXT to a group!"
+
+                action {
+                    respond {
+                        content = "Ah-ah-ah!"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
this is legal now

Note that I haven't reconfigured the maximum subcommand/group limit (it still applies to subcommands and groups individually), and I can't actually find mention of this limit in the official documentation.