### PR TITLE
mongo adapter: Allow reading of old INT64 Snowflake from databases

### DIFF
--- a/data-adapters/adapter-mongodb/src/main/kotlin/com/kotlindiscord/kord/extensions/adapters/mongodb/codecs/SnowflakeCodec.kt
+++ b/data-adapters/adapter-mongodb/src/main/kotlin/com/kotlindiscord/kord/extensions/adapters/mongodb/codecs/SnowflakeCodec.kt
@@ -7,6 +7,7 @@
 package com.kotlindiscord.kord.extensions.adapters.mongodb.codecs
 
 import dev.kord.common.entity.Snowflake
+import org.bson.BsonInvalidOperationException
 import org.bson.BsonReader
 import org.bson.BsonWriter
 import org.bson.codecs.Codec
@@ -15,10 +16,10 @@ import org.bson.codecs.EncoderContext
 
 public object SnowflakeCodec : Codec<Snowflake> {
     override fun decode(reader: BsonReader, decoderContext: DecoderContext): Snowflake = try {
-        Snowflake(reader.readString())
-	} catch (e: BsonInvalidOperationException) {
-		Snowflake(reader.readInt64())
-	}
+	    Snowflake(reader.readString())
+    } catch (e: BsonInvalidOperationException) {
+	    Snowflake(reader.readInt64())
+    }
 
     override fun encode(writer: BsonWriter, value: Snowflake, encoderContext: EncoderContext) {
         writer.writeString(value.toString())

--- a/data-adapters/adapter-mongodb/src/main/kotlin/com/kotlindiscord/kord/extensions/adapters/mongodb/codecs/SnowflakeCodec.kt
+++ b/data-adapters/adapter-mongodb/src/main/kotlin/com/kotlindiscord/kord/extensions/adapters/mongodb/codecs/SnowflakeCodec.kt
@@ -14,8 +14,11 @@ import org.bson.codecs.DecoderContext
 import org.bson.codecs.EncoderContext
 
 public object SnowflakeCodec : Codec<Snowflake> {
-    override fun decode(reader: BsonReader, decoderContext: DecoderContext): Snowflake =
+    override fun decode(reader: BsonReader, decoderContext: DecoderContext): Snowflake = try {
         Snowflake(reader.readString())
+	} catch (e: BsonInvalidOperationException) {
+		Snowflake(reader.readInt64())
+	}
 
     override fun encode(writer: BsonWriter, value: Snowflake, encoderContext: EncoderContext) {
         writer.writeString(value.toString())


### PR DESCRIPTION
Without this, any Snowflake entry in a database record that was created using KMongo, which serialized Snowflakes as INT64, will throw an error. This allows proper decoding of those INT64 entries, alongside the STRING entries