### PR TITLE
Set guildId to null when registering unsafeSubCommand in group

### DIFF
--- a/modules/unsafe/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/unsafe/extensions/_SlashCommands.kt
+++ b/modules/unsafe/src/main/kotlin/com/kotlindiscord/kord/extensions/modules/unsafe/extensions/_SlashCommands.kt
@@ -122,6 +122,8 @@ public suspend fun <T : Arguments> SlashGroup.unsafeSubCommand(
 public fun <T : Arguments, M : ModalForm> SlashGroup.unsafeSubCommand(
     commandObj: UnsafeSlashCommand<T, M>
 ): UnsafeSlashCommand<T, M> {
+	commandObj.guildId = null
+
     if (subCommands.size >= SUBCOMMAND_AND_GROUP_LIMIT) {
         throw InvalidCommandException(
             commandObj.name,


### PR DESCRIPTION
This should fix the error message shown when using a `defaultGuild` in the bot's configuration and registering a `unsafeSubcommand` under a `group`