### PR TITLE
Change extension name sentry context to a mapping

### DIFF
--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/message/MessageCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/message/MessageCommand.kt
@@ -75,7 +75,11 @@ public abstract class MessageCommand<C : MessageCommandContext<C, M>, M : ModalF
 			)
 
 			context.sentry.context(
-				"extension", extension.name
+				"extension",
+
+				mapOf(
+					"name" to extension.name
+				)
 			)
 
 			context.sentry.breadcrumb(BreadcrumbType.User) {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/message/MessageCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/message/MessageCommand.kt
@@ -70,15 +70,8 @@ public abstract class MessageCommand<C : MessageCommandContext<C, M>, M : ModalF
 
 				mapOf(
 					"name" to name,
-					"type" to "message"
-				)
-			)
-
-			context.sentry.context(
-				"extension",
-
-				mapOf(
-					"name" to extension.name
+					"type" to "message",
+					"extension" to extension.name,
 				)
 			)
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/SlashCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/SlashCommand.kt
@@ -198,7 +198,11 @@ public abstract class SlashCommand<C : SlashCommandContext<*, A, M>, A : Argumen
 			)
 
 			context.sentry.context(
-				"extension", extension.name
+				"extension",
+
+				mapOf(
+					"name" to extension.name
+				)
 			)
 
 			context.sentry.breadcrumb(BreadcrumbType.User) {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/SlashCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/SlashCommand.kt
@@ -193,16 +193,11 @@ public abstract class SlashCommand<C : SlashCommandContext<*, A, M>, A : Argumen
 
 				mapOf(
 					"name" to name,
-					"type" to "slash"
-				)
-			)
-
-			context.sentry.context(
-				"extension",
-
-				mapOf(
-					"name" to extension.name
-				)
+					"type" to "slash",
+					"extension" to extension.name,
+					"parent" to parentCommand?.name,
+					"group" to parentGroup?.name,
+				).filterValues { it != null }
 			)
 
 			context.sentry.breadcrumb(BreadcrumbType.User) {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/SlashCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/slash/SlashCommand.kt
@@ -188,16 +188,28 @@ public abstract class SlashCommand<C : SlashCommandContext<*, A, M>, A : Argumen
 	/** If enabled, adds the initial Sentry breadcrumb to the given context. **/
 	public open suspend fun firstSentryBreadcrumb(context: C, commandObj: SlashCommand<*, *, *>) {
 		if (sentry.enabled) {
+			val fullName = buildString {
+				parentCommand?.let {
+					append(it.name)
+					append(" ")
+				}
+
+				parentGroup?.let {
+					append(it.name)
+					append(" ")
+				}
+
+				append(name)
+			}
+
 			context.sentry.context(
 				"command",
 
 				mapOf(
-					"name" to name,
+					"name" to fullName,
 					"type" to "slash",
-					"extension" to extension.name,
-					"parent" to parentCommand?.name,
-					"group" to parentGroup?.name,
-				).filterValues { it != null }
+					"extension" to extension.name
+				)
 			)
 
 			context.sentry.breadcrumb(BreadcrumbType.User) {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/user/UserCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/user/UserCommand.kt
@@ -70,15 +70,8 @@ public abstract class UserCommand<C : UserCommandContext<C, M>, M : ModalForm>(
 
 				mapOf(
 					"name" to name,
-					"type" to "user"
-				)
-			)
-
-			context.sentry.context(
-				"extension",
-
-				mapOf(
-					"name" to extension.name
+					"type" to "user",
+					"extension" to extension.name,
 				)
 			)
 

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/user/UserCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/application/user/UserCommand.kt
@@ -75,7 +75,11 @@ public abstract class UserCommand<C : UserCommandContext<C, M>, M : ModalForm>(
 			)
 
 			context.sentry.context(
-				"extension", extension.name
+				"extension",
+
+				mapOf(
+					"name" to extension.name
+				)
 			)
 
 			context.sentry.breadcrumb(BreadcrumbType.User) {

--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/chat/ChatCommand.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/commands/chat/ChatCommand.kt
@@ -385,12 +385,9 @@ public open class ChatCommand<T : Arguments>(
 
 				mapOf(
 					"name" to translatedName,
-					"type" to "chat"
+					"type" to "chat",
+					"extension" to extension.name,
 				)
-			)
-
-			context.sentry.context(
-				"extension", extension.name
 			)
 
 			context.sentry.breadcrumb(BreadcrumbType.User) {


### PR DESCRIPTION
We discussed this briefly on Discord: https://canary.discord.com/channels/1121419906995458098/1210756178515206164

But basically, Sentry is expecting an object, not a single value, so it shows this warning:

![image](https://github.com/Kord-Extensions/kord-extensions/assets/12865379/380f6bd3-da03-457e-a957-6145b048e14e)

This is **ready** as it is, but this change made me think of further possible changes:

1. Do we want to have Sentry show another "section" for a single value, or should `extension.name` be merged into `command` as `command.extension`?.  
![image](https://github.com/Kord-Extensions/kord-extensions/assets/12865379/ca64f08d-8e76-4837-83e5-3815e281e88e)
2. Also noticing that for slash commands, only the command/subcommand's name is shown, and no information on parent command is shown ( the command in the above picture is actually `/respawn-manage bump-user`). So I'm thinking of doing either of these:
   1.  Leave `name` as is, add `parent` if it is a subcommand and put the parent's name there.
   2. Make `name` always be the root command, and add `subcommand` if it is a subcommand? Probably a good idea to also have `group` in here.  

I think having just the name would be ambiguous as it is common to have a pattern like: `/guild edit`, `/member edit`, `/channel edit`, so they would all be listed as "edit".