### PR TITLE
Use mappings for EventHandler sentry context

### DIFF
--- a/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventHandler.kt
+++ b/kord-extensions/src/main/kotlin/com/kotlindiscord/kord/extensions/events/EventHandler.kt
@@ -154,11 +154,12 @@ public open class EventHandler<T : Event>(
 
 		if (sentry.enabled) {
 			context.sentry.context(
-				"event", eventName ?: "Unknown",
-			)
+				"event",
 
-			context.sentry.context(
-				"extension", extension.name
+				mapOf(
+					"name" to (eventName ?: "Unknown"),
+					"extension" to extension.name
+				),
 			)
 
 			context.sentry.breadcrumb(BreadcrumbType.Info) {


### PR DESCRIPTION
Giving these the same treatment as #295 

![image](https://github.com/Kord-Extensions/kord-extensions/assets/12865379/a0cf9052-e405-472c-b1bf-33266892d212)

Using a mapping, and merging extension name into it to match the structure used in commands.