### PR TITLE
Check permissions before running phishing actions

### DIFF
--- a/modules/functionality/func-phishing/src/main/kotlin/dev/kordex/modules/func/phishing/DetectionAction.kt
+++ b/modules/functionality/func-phishing/src/main/kotlin/dev/kordex/modules/func/phishing/DetectionAction.kt
@@ -16,18 +16,19 @@ import dev.kordex.modules.func.phishing.i18n.generated.PhishingTranslations
  *
  * The extension will always try to log the message, but you can specify [LogOnly] if that's _all_ you want.
  *
+ * @property name The name of the action. Used for logging.
  * @property message Message to return to the user.
  */
-sealed class DetectionAction(val message: Key) {
+sealed class DetectionAction(val name: Key, val message: Key) {
 	/** Ban 'em and delete the message. **/
-	object Ban : DetectionAction(PhishingTranslations.Actions.Ban.text)
+	object Ban : DetectionAction(PhishingTranslations.Actions.Ban.name, PhishingTranslations.Actions.Ban.text)
 
 	/** Delete the message. **/
-	object Delete : DetectionAction(PhishingTranslations.Actions.Delete.text)
+	object Delete : DetectionAction(PhishingTranslations.Actions.Delete.name, PhishingTranslations.Actions.Delete.text)
 
 	/** Kick 'em and delete the message. **/
-	object Kick : DetectionAction(PhishingTranslations.Actions.Kick.text)
+	object Kick : DetectionAction(PhishingTranslations.Actions.Kick.name, PhishingTranslations.Actions.Kick.text)
 
 	/** Don't do anything, just log it in the logs channel. **/
-	object LogOnly : DetectionAction(PhishingTranslations.Actions.LogOnly.text)
+	object LogOnly : DetectionAction(PhishingTranslations.Actions.LogOnly.name, PhishingTranslations.Actions.LogOnly.text)
 }

--- a/modules/functionality/func-phishing/src/main/kotlin/dev/kordex/modules/func/phishing/PhishingExtension.kt
+++ b/modules/functionality/func-phishing/src/main/kotlin/dev/kordex/modules/func/phishing/PhishingExtension.kt
@@ -362,9 +362,9 @@ class PhishingExtension(private val settings: ExtPhishingBuilder) : Extension() 
 						inline = true
 
 						name = PhishingTranslations.Fields.ActionFailed.name.translateLocale(locale)
-						value = PhishingTranslations.Fields.ActionFailed.value.translateLocale(
+						value = PhishingTranslations.Fields.ActionFailed.value.translateNamedLocale(
 							locale,
-							settings.detectionAction.name
+							"action" to settings.detectionAction.name
 						)
 					}
 				}

--- a/modules/functionality/func-phishing/src/main/kotlin/dev/kordex/modules/func/phishing/PhishingExtension.kt
+++ b/modules/functionality/func-phishing/src/main/kotlin/dev/kordex/modules/func/phishing/PhishingExtension.kt
@@ -12,7 +12,6 @@ package dev.kordex.modules.func.phishing
 
 import dev.kord.common.asJavaLocale
 import dev.kord.common.entity.Permission
-import dev.kord.common.entity.Snowflake
 import dev.kord.core.behavior.ban
 import dev.kord.core.behavior.channel.createMessage
 import dev.kord.core.entity.Message
@@ -241,7 +240,7 @@ class PhishingExtension(private val settings: ExtPhishingBuilder) : Extension() 
 			val selfAsMember = kord.getSelf().asMemberOrNull(message.getGuild().id)
 
 			when (settings.detectionAction) {
-				DetectionAction.Ban -> {
+				DetectionAction.Ban ->
 					if (selfAsMember?.hasPermissions(Permission.BanMembers, Permission.ManageMessages) == true) {
 						message.getAuthorAsMemberOrNull()!!.ban {
 							reason = translatedLogMessage
@@ -251,24 +250,21 @@ class PhishingExtension(private val settings: ExtPhishingBuilder) : Extension() 
 					} else {
 						actionSuccess = false
 					}
-				}
 
-				DetectionAction.Delete -> {
+				DetectionAction.Delete ->
 					if (selfAsMember?.hasPermissions(Permission.ManageMessages) == true) {
 						message.delete(translatedLogMessage)
 					} else {
 						actionSuccess = false
 					}
-				}
 
-				DetectionAction.Kick -> {
+				DetectionAction.Kick ->
 					if (selfAsMember?.hasPermissions(Permission.KickMembers, Permission.BanMembers) == true) {
 						message.getAuthorAsMemberOrNull()!!.kick(translatedLogMessage)
 						message.delete(translatedLogMessage)
 					} else {
 						actionSuccess = false
 					}
-				}
 
 				DetectionAction.LogOnly -> {
 					// Do nothing, we always log

--- a/modules/functionality/func-phishing/src/main/kotlin/dev/kordex/modules/func/phishing/PhishingExtension.kt
+++ b/modules/functionality/func-phishing/src/main/kotlin/dev/kordex/modules/func/phishing/PhishingExtension.kt
@@ -19,6 +19,7 @@ import dev.kord.core.entity.channel.GuildMessageChannel
 import dev.kord.core.event.message.MessageCreateEvent
 import dev.kord.core.event.message.MessageUpdateEvent
 import dev.kord.rest.builder.message.embed
+import dev.kord.rest.request.RestRequestException
 import dev.kordex.core.DISCORD_RED
 import dev.kordex.core.checks.anyGuild
 import dev.kordex.core.checks.hasPermission
@@ -235,42 +236,46 @@ class PhishingExtension(private val settings: ExtPhishingBuilder) : Extension() 
 				.translate()
 
 			var actionSuccess = true
-			val selfAsMember = kord.getSelf().asMemberOrNull(message.getGuild().id)
 
 			when (settings.detectionAction) {
 				DetectionAction.Ban -> {
-					if (selfAsMember?.hasPermissions(Permission.BanMembers) == true) {
+					try {
 						message.getAuthorAsMemberOrNull()!!.ban {
 							reason = translatedLogMessage
 						}
-					} else {
+					} catch (e: RestRequestException) {
+						logger.trace(e) { "Failed to ban user due to missing permissions" }
 						actionSuccess = false
 					}
 
-					if (selfAsMember?.hasPermissions(Permission.ManageMessages) == true) {
+					try {
 						message.delete(translatedLogMessage)
-					} else {
+					} catch (e: RestRequestException) {
+						logger.trace(e) { "Failed to delete message due to missing permissions" }
 						actionSuccess = false
 					}
 				}
 
 				DetectionAction.Delete ->
-					if (selfAsMember?.hasPermissions(Permission.ManageMessages) == true) {
+					try {
 						message.delete(translatedLogMessage)
-					} else {
+					} catch (e: RestRequestException) {
+						logger.trace(e) { "Failed to delete message due to missing permissions" }
 						actionSuccess = false
 					}
 
 				DetectionAction.Kick -> {
-					if (selfAsMember?.hasPermissions(Permission.KickMembers) == true) {
+					try {
 						message.getAuthorAsMemberOrNull()!!.kick(translatedLogMessage)
-					} else {
+					} catch (e: RestRequestException) {
+						logger.trace(e) { "Failed to kick user due to missing permissions" }
 						actionSuccess = false
 					}
 
-					if (selfAsMember?.hasPermissions(Permission.ManageMessages) == true) {
+					try {
 						message.delete(translatedLogMessage)
-					} else {
+					} catch (e: RestRequestException) {
+						logger.trace(e) { "Failed to delete message due to missing permissions" }
 						actionSuccess = false
 					}
 				}

--- a/modules/functionality/func-phishing/src/main/kotlin/dev/kordex/modules/func/phishing/PhishingExtension.kt
+++ b/modules/functionality/func-phishing/src/main/kotlin/dev/kordex/modules/func/phishing/PhishingExtension.kt
@@ -11,7 +11,6 @@
 package dev.kordex.modules.func.phishing
 
 import dev.kord.common.asJavaLocale
-import dev.kord.common.entity.Permission
 import dev.kord.core.behavior.ban
 import dev.kord.core.behavior.channel.createMessage
 import dev.kord.core.entity.Message
@@ -32,7 +31,6 @@ import dev.kordex.core.extensions.ephemeralSlashCommand
 import dev.kordex.core.extensions.event
 import dev.kordex.core.utils.dm
 import dev.kordex.core.utils.getJumpUrl
-import dev.kordex.core.utils.hasPermissions
 import dev.kordex.core.utils.kordExUserAgent
 import dev.kordex.modules.func.phishing.i18n.generated.PhishingTranslations
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/modules/functionality/func-phishing/src/main/kotlin/dev/kordex/modules/func/phishing/PhishingExtension.kt
+++ b/modules/functionality/func-phishing/src/main/kotlin/dev/kordex/modules/func/phishing/PhishingExtension.kt
@@ -10,7 +10,6 @@
 
 package dev.kordex.modules.func.phishing
 
-import com.kotlindiscord.kord.extensions.commands.converters.impl.string
 import dev.kord.common.asJavaLocale
 import dev.kord.common.entity.Permission
 import dev.kord.core.behavior.ban
@@ -25,6 +24,7 @@ import dev.kordex.core.checks.anyGuild
 import dev.kordex.core.checks.hasPermission
 import dev.kordex.core.checks.isNotBot
 import dev.kordex.core.commands.Arguments
+import dev.kordex.core.commands.converters.impl.string
 import dev.kordex.core.extensions.Extension
 import dev.kordex.core.extensions.ephemeralMessageCommand
 import dev.kordex.core.extensions.ephemeralSlashCommand
@@ -289,7 +289,8 @@ class PhishingExtension(private val settings: ExtPhishingBuilder) : Extension() 
 
 		if (!actionSuccess) {
 			logger.warn {
-				"Unable to run ${settings.detectionAction.name} action on ${guild.name} (${guild.id.value}) due to missing permissions"
+				"Unable to run ${settings.detectionAction.name} action on ${guild.name}" +
+					" (${guild.id.value}) due to missing permissions"
 			}
 		}
 


### PR DESCRIPTION
Previously an error would be thrown if permissions were missing for a detection action in the phishing module. This PR adds some checks in to ensure the permissions are present in the bot before running those actions. If the permissions aren't present then it will send a warning to the console logs and insert a field to the logging embed that states permissions are missing.

I do have a question, should the checks on ban and kick be seperate to the delete check so that if the bot has one but not the other permission, one of the actions still gets run?

I haven't PR'd the fields to the translations repo yet, wanted to ensure the code was acceptable first. 

