### PR TITLE
Generalize modal components and add support for text displays

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=2048m
 org.gradle.parallel=true
 kotlin.incremental=true
 ksp.incremental=false
-projectVersion=2.5.0-SNAPSHOT
+projectVersion=2.6.0-SNAPSHOT

--- a/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/Form.kt
+++ b/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/Form.kt
@@ -21,13 +21,6 @@ public abstract class Form {
 	/** How long to wait before we stop waiting for this modal to be submitted. **/
 	public open val timeout: Duration = Duration.ZERO
 
-//    /** Widgets that haven't been sorted into the grid by [pack] yet. **/
-//    public open val unsortedComponents: MutableList<Component> = mutableListOf()
-
 	/** A grid containing rows of widgets. **/
 	public open val grid: WidgetGrid = WidgetGrid()
-
-//    public abstract fun pack()
-//    public abstract fun update()
-//    public abstract fun destroy()
 }

--- a/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/FormTextDisplay.kt
+++ b/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/FormTextDisplay.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyrighted (Kord Extensions, 2026). Licensed under the EUPL-1.2
+ * with the specific provision (EUPL articles 14 & 15) that the
+ * applicable law is the (Republic of) Irish law and the Jurisdiction
+ * Dublin.
+ * Any redistribution must include the specific provision above.
+ */
+
+package dev.kordex.core.components.forms
+
+import dev.kord.rest.builder.interaction.ModalBuilder
+import dev.kordex.i18n.Key
+import java.util.*
+
+/**
+ * A widget representing rich Markdown-formatted content.
+ */
+public class FormTextDisplay : Widget() {
+	@Suppress("MagicNumber")
+	override var width: Int = 5
+	override var height: Int = 1
+
+	/** This component's Markdown content. **/
+	public lateinit var content: Key
+
+	override suspend fun apply(
+		builder: ModalBuilder,
+		locale: Locale,
+	) {
+		val translatedContent = content
+			.withLocale(locale)
+			.translate()
+
+		builder.textDisplay {
+			this.content = translatedContent
+		}
+	}
+
+	override fun validate() {
+		if (this::content.isInitialized.not() || content.key.isEmpty()) {
+			error("FormTextDisplay must have content, but none was provided.")
+		}
+	}
+}

--- a/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/ModalForm.kt
+++ b/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/ModalForm.kt
@@ -56,6 +56,21 @@ public abstract class ModalForm : Form(), KordExKoinComponent {
 	/** ID representing this modal on Discord. **/
 	public var id: String = UUID.randomUUID().toString()
 
+	/** A component representing Markdown-formatted text content. **/
+	public fun textDisplay(
+		coordinate: CoordinatePair? = null,
+		builder: FormTextDisplay.() -> Unit,
+	): FormTextDisplay {
+		val component = FormTextDisplay()
+
+		builder(component)
+		component.validate()
+
+		grid.setAtCoordinateOrFirstRow(coordinate, component)
+
+		return component
+	}
+
 	/** A widget representing a single-line text input. **/
 	public fun lineText(
 		coordinate: CoordinatePair? = null,
@@ -216,12 +231,14 @@ public abstract class ModalForm : Form(), KordExKoinComponent {
 	public suspend fun call(event: ModalSubmitInteractionCreateEvent) {
 		val interaction = event.interaction
 
-		grid.filter { it.isNotEmpty() }.flatten().forEach { widget -> getWidgetValue(widget, interaction)  }
+		grid.filter { it.isNotEmpty() }.flatten()
+			.filterIsInstance<InteractableWidget<*>>()
+			.forEach { component -> getWidgetValue(component, interaction)  }
 
 		bot.send(ModalInteractionCompleteEvent(id, interaction))
 	}
 
-	private fun getWidgetValue(widget: Widget<*>?, interaction: ModalSubmitInteraction) {
+	private fun getWidgetValue(widget: InteractableWidget<*>?, interaction: ModalSubmitInteraction) {
 		when (widget) {
 			is TextInputWidget<*> -> interaction.textInputs[widget.id]?.value?.let(widget::setValue)
 
@@ -251,19 +268,17 @@ public abstract class ModalForm : Form(), KordExKoinComponent {
 
 	/** Given a ModalBuilder, apply this modal's widgets for display on Discord. **/
 	public suspend fun applyToBuilder(builder: ModalBuilder, locale: Locale) {
-		val appliedWidgets = mutableSetOf<Widget<*>>()
+		val appliedComponents = mutableSetOf<Widget>()
 
 		grid.forEach { row ->
 			val filteredRow = row.filterNotNull()
-				.filter { it !in appliedWidgets }
+				.filter { it !in appliedComponents }
 
 			if (filteredRow.isNotEmpty()) {
-				filteredRow.forEach { widget ->
-					if (widget !in appliedWidgets) {
-						builder.label(widget.label.withLocale(locale).translate()) {
-							widget.apply(this, locale)
-							appliedWidgets.add(widget)
-						}
+				filteredRow.forEach { component ->
+					if (component !in appliedComponents) {
+						component.apply(builder, locale)
+						appliedComponents.add(component)
 					}
 				}
 			}

--- a/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/Widget.kt
+++ b/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/Widget.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyrighted (Kord Extensions, 2026). Licensed under the EUPL-1.2
+ * with the specific provision (EUPL articles 14 & 15) that the
+ * applicable law is the (Republic of) Irish law and the Jurisdiction
+ * Dublin.
+ * Any redistribution must include the specific provision above.
+ */
+
+package dev.kordex.core.components.forms
+
+import dev.kord.rest.builder.interaction.ModalBuilder
+import java.util.*
+
+/**
+ * A component usable inside modal forms.
+ */
+public abstract class Widget {
+	/** How wide this component is, in grid cells. **/
+	public abstract var width: Int
+		protected set
+
+	/** How tall this component is, in grid cells. **/
+	public abstract var height: Int
+		protected set
+
+	override fun toString(): String =
+		"${this::class.simpleName}@${hashCode()} ($width x $height)"
+
+	/** Function called to apply this component to a Discord form. **/
+	public abstract suspend fun apply(builder: ModalBuilder, locale: Locale)
+
+	/** Function called to ensure that this component was set up correctly. **/
+	public abstract fun validate()
+}

--- a/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/_Grid.kt
+++ b/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/_Grid.kt
@@ -10,10 +10,9 @@
 
 package dev.kordex.core.components.forms
 
-import dev.kordex.core.components.forms.widgets.Widget
 import dev.kordex.core.utils.map
 
-public typealias WidgetGrid = Array<MutableList<Widget<*>?>>
+public typealias WidgetGrid = Array<MutableList<Widget?>>
 
 /** A coordinate pair, represented by a `Pair(row, column)`. **/
 public typealias CoordinatePair = Pair<Int, Int>
@@ -173,18 +172,18 @@ public fun WidgetGrid.toString(): String = buildString {
 @Suppress("USELESS_CAST", "SpreadOperator")  // You're just wrong here, IJ
 public fun WidgetGrid(): WidgetGrid = arrayOf(
 	*GRID_HEIGHT.map {
-		GRID_WIDTH.map { null as Widget<*>? }.toMutableList()
+		GRID_WIDTH.map { null as Widget? }.toMutableList()
 	}.toTypedArray()
 )
 
-public fun WidgetGrid.get(coordinate: CoordinatePair): Widget<*>? {
+public fun WidgetGrid.get(coordinate: CoordinatePair): Widget? {
 	coordinate.throwIfInvalid()
 
 	return this[coordinate.first].getOrNull(coordinate.second)
 }
 
 @Suppress("UnnecessaryParentheses")
-public fun WidgetGrid.setAtCoordinateOrFirstRow(coordinate: CoordinatePair?, widget: Widget<*>) {
+public fun WidgetGrid.setAtCoordinateOrFirstRow(coordinate: CoordinatePair?, widget: Widget) {
 	if (coordinate == null) {
 		val row = indexOfFirst { (GRID_WIDTH - it.count { e -> e != null }) >= widget.width }
 
@@ -200,7 +199,7 @@ public fun WidgetGrid.setAtCoordinateOrFirstRow(coordinate: CoordinatePair?, wid
 	}
 }
 
-public fun WidgetGrid.set(coordinate: CoordinatePair, widget: Widget<*>) {
+public fun WidgetGrid.set(coordinate: CoordinatePair, widget: Widget) {
 	coordinate.throwIfInvalid("Start coordinate")
 
 	val end = coordinate + (widget.height - 1 x widget.width - 1)
@@ -228,19 +227,19 @@ public fun WidgetGrid.removeAt(coordinate: CoordinatePair): Boolean =
 		false
 	}
 
-public fun WidgetGrid.remove(widget: Widget<*>): Boolean {
+public fun WidgetGrid.remove(widget: Widget): Boolean {
 	val coordinates = coordinatesFor(widget)
 
 	if (coordinates.isEmpty()) {
 		return false
 	}
 
-	coordinates.map(::removeAt)
+	coordinates.forEach(::removeAt)
 
 	return true
 }
 
-public fun WidgetGrid.coordinatesFor(widget: Widget<*>): List<CoordinatePair> {
+public fun WidgetGrid.coordinatesFor(widget: Widget): List<CoordinatePair> {
 	val values = mutableListOf<CoordinatePair>()
 
 	forEachIndexed { rowIndex, row ->
@@ -254,13 +253,13 @@ public fun WidgetGrid.coordinatesFor(widget: Widget<*>): List<CoordinatePair> {
 	return values
 }
 
-public fun WidgetGrid.getWidgetSet(): Set<Widget<*>> {
-	val values = mutableSetOf<Widget<*>>()
+public fun WidgetGrid.getWidgetSet(): Set<Widget> {
+	val values = mutableSetOf<Widget>()
 
 	forEach { row ->
-		row.forEach { widget ->
-			if (widget != null) {
-				values.add(widget)
+		row.forEach { component ->
+			if (component != null) {
+				values.add(component)
 			}
 		}
 	}

--- a/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/widgets/CheckboxGroupWidget.kt
+++ b/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/widgets/CheckboxGroupWidget.kt
@@ -15,7 +15,7 @@ import dev.kordex.i18n.Key
 import java.util.*
 
 /** A checkbox widget that supports multiple checkboxes. **/
-public class CheckboxGroupWidget : Widget<List<String>>(), KordExKoinComponent {
+public class CheckboxGroupWidget : InteractableWidget<List<String>>(), KordExKoinComponent {
 	@Suppress("MagicNumber")
 	override var width: Int = 5
 	override var height: Int = 1

--- a/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/widgets/CheckboxWidget.kt
+++ b/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/widgets/CheckboxWidget.kt
@@ -14,7 +14,7 @@ import dev.kordex.i18n.Key
 import java.util.*
 
 /** A checkbox widget that supports a single checkbox. **/
-public class CheckboxWidget : Widget<Boolean?>(), KordExKoinComponent {
+public class CheckboxWidget : InteractableWidget<Boolean?>(), KordExKoinComponent {
 	@Suppress("MagicNumber")
 	override var width: Int = 5
 	override var height: Int = 1

--- a/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/widgets/FileUploadWidget.kt
+++ b/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/widgets/FileUploadWidget.kt
@@ -16,7 +16,7 @@ import java.util.Locale
 import java.util.UUID
 
 /** A widget for uploading files to discord. **/
-public class FileUploadWidget : Widget<List<Snowflake>?>(), KordExKoinComponent {
+public class FileUploadWidget : InteractableWidget<List<Snowflake>?>(), KordExKoinComponent {
 	@Suppress("MagicNumber")
 	override var width: Int = 5
 	override var height: Int = 1

--- a/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/widgets/InteractableWidget.kt
+++ b/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/widgets/InteractableWidget.kt
@@ -9,19 +9,13 @@
 package dev.kordex.core.components.forms.widgets
 
 import dev.kord.rest.builder.component.LabelComponentBuilder
+import dev.kord.rest.builder.interaction.ModalBuilder
+import dev.kordex.core.components.forms.Widget
 import dev.kordex.i18n.Key
 import java.util.*
 
-/** Abstract type representing a grid-based widget. **/
-public abstract class Widget<T> {
-	/** How wide this widget is, in grid cells. **/
-	public abstract var width: Int
-		protected set
-
-	/** How tall this widget is, in grid cells. **/
-	public abstract var height: Int
-		protected set
-
+/** Abstract type representing an interactable [Widget]. **/
+public abstract class InteractableWidget<T> : Widget() {
 	/** The final value stored in this widget, as provided by the user. **/
 	public abstract var value: T
 		protected set
@@ -34,12 +28,11 @@ public abstract class Widget<T> {
 	public abstract var description: Key?
 		protected set
 
-	override fun toString(): String =
-		"${this::class.simpleName}@${hashCode()} ($width x $height)"
-
-	/** Function called to apply this widget to a Discord action row. **/
 	public abstract suspend fun apply(builder: LabelComponentBuilder, locale: Locale)
 
-	/** Function called to ensure that this widget was set up correctly. **/
-	public abstract fun validate()
+	public final override suspend fun apply(builder: ModalBuilder, locale: Locale) {
+		builder.label(label.withLocale(locale).translate()) {
+			apply(this, locale)
+		}
+	}
 }

--- a/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/widgets/RadioGroupWidget.kt
+++ b/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/widgets/RadioGroupWidget.kt
@@ -23,8 +23,8 @@ private const val MAX_OPTIONS: Int = 10
 /** A widget for selecting exactly one option from a defined list. **/
 public class RadioGroupWidget : InteractableWidget<String?>(), KordExKoinComponent {
 	@Suppress("MagicNumber")
-	override var height: Int = 5
-	override var width: Int = 1
+	override var width: Int = 5
+	override var height: Int = 1
 	override var value: String? = null
 
 	/** The widget's unique ID on Discord, defaulting to a UUID. **/

--- a/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/widgets/RadioGroupWidget.kt
+++ b/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/widgets/RadioGroupWidget.kt
@@ -21,7 +21,7 @@ private const val MIN_OPTIONS: Int = 2
 private const val MAX_OPTIONS: Int = 10
 
 /** A widget for selecting exactly one option from a defined list. **/
-public class RadioGroupWidget : Widget<String?>(), KordExKoinComponent {
+public class RadioGroupWidget : InteractableWidget<String?>(), KordExKoinComponent {
 	@Suppress("MagicNumber")
 	override var height: Int = 5
 	override var width: Int = 1

--- a/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/widgets/TextInputWidget.kt
+++ b/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/widgets/TextInputWidget.kt
@@ -29,7 +29,7 @@ public const val LABEL_LENGTH: Int = 45
 public const val TEXT_INPUT_PLACEHOLDER_LENGTH: Int = 100
 
 /** An abstract type representing a widget that accepts text from the user. */
-public abstract class TextInputWidget<T : TextInputWidget<T>> : Widget<String?>(), KordExKoinComponent {
+public abstract class TextInputWidget<T : TextInputWidget<T>> : InteractableWidget<String?>(), KordExKoinComponent {
 	private val logger = KotlinLogging.logger { }
 
 	@Suppress("MagicNumber")

--- a/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/widgets/menus/SelectMenuWidget.kt
+++ b/kord-extensions/src/main/kotlin/dev/kordex/core/components/forms/widgets/menus/SelectMenuWidget.kt
@@ -8,10 +8,10 @@
 
 package dev.kordex.core.components.forms.widgets.menus
 
+import dev.kordex.core.components.forms.widgets.InteractableWidget
 import dev.kordex.core.components.forms.widgets.MAX_LENGTH
 import dev.kordex.core.components.forms.widgets.MIN_LENGTH
 import dev.kordex.core.components.forms.widgets.MIN_VALUES
-import dev.kordex.core.components.forms.widgets.Widget
 import dev.kordex.core.koin.KordExKoinComponent
 import dev.kordex.i18n.Key
 import java.util.*
@@ -22,7 +22,8 @@ public const val MAX_VALUES: Int = 25
 /** The maximum number of characters that can be present in the select widget's placeholder. **/
 public const val SELECT_PLACEHOLDER_LENGTH: Int = 150
 
-public abstract class SelectMenuWidget<C, T : SelectMenuWidget<C, T>> : Widget<List<C?>>(), KordExKoinComponent {
+public abstract class SelectMenuWidget<C, T : SelectMenuWidget<C, T>> :
+	InteractableWidget<List<C?>>(), KordExKoinComponent {
 
 	@Suppress("MagicNumber")
 	override var width: Int = 5


### PR DESCRIPTION
Previously, KordEx's `ModalForm` API only supported interactive `Widgets`, which return user input. In the current Discord API though, you can have [Text Displays](https://docs.discord.com/developers/components/reference#text-display) on modals too, at the root level.

This commit generalizes the root modal API a bit so it can support these text display components, while keeping the existing `Widget` API pretty much intact.